### PR TITLE
code fixes issues #3, #27, #30, and part of #45 and #46

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -404,7 +404,6 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       ct_window_width_hbox.addWidget(self.ct_window_width_label)
       
       self.ct_window_width_line_edit = qt.QLineEdit(self.ct_window_width_selected)
-      onlyInt = qt.QIntValidator()
       self.ct_window_width_line_edit.setValidator(onlyInt)
       ct_window_width_hbox.addWidget(self.ct_window_width_line_edit)
 
@@ -414,6 +413,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       # TODO Delph : create buttons
 
       # if classification : configure checkboxes, comboboxes, text fields
+      # create but for QIntValidator not working anywhere in the file
 
       ##########################################
 
@@ -793,7 +793,6 @@ class ConfigureLabelsWindow(qt.QWidget):
           self.label_table_view.horizontalHeader().setSectionResizeMode(qt.QHeaderView.Stretch)
 
           for index, label in enumerate(self.label_config_yaml['labels']): 
-                # TODO Delph LIVE : QIntValidator not working???
                 edit_button = qt.QPushButton('Edit')
                 edit_button.clicked.connect(lambda state, label = label: self.push_edit_button(label))
                 edit_button_hbox = qt.QHBoxLayout()

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -322,10 +322,27 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       layout.addLayout(bids_hbox)
 
+      file_extension_hbox = qt.QHBoxLayout()
+
+      self.file_extension_label = qt.QLabel()
+      self.file_extension_label.setText('Input File Extension : ')
+      self.file_extension_label.setStyleSheet("font-weight: bold")
+      file_extension_hbox.addWidget(self.file_extension_label)
+
+      self.file_extension_combobox = qt.QComboBox()
+      self.file_extension_combobox.addItem('*.nii.gz')
+      self.file_extension_combobox.addItem('*.nrrd')
+
+      self.file_extension_selected = '*.nii.gz'
+
+      self.file_extension_combobox.currentIndexChanged.connect(self.update_file_extension)
+      file_extension_hbox.addWidget(self.file_extension_combobox)
+
+      layout.addLayout(file_extension_hbox)
+
       ##########################################
       # TODO Delph : create buttons
 
-      # specify file extension to be used
       # specify initial scan view (sagittal, coronal, axial)
       # specify interpolate 
       # if segmentation : configure labels (if CT : configure thresholds)
@@ -356,6 +373,9 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        else: 
             self.include_semi_automatic_PHE_tool_label.setVisible(False)
             self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+   
+   def update_file_extension(self):
+       self.file_extension_selected = self.file_extension_combobox.currentText
    
    def update_bids(self):
        self.bids_selected = self.bids_combobox.currentText
@@ -408,6 +428,8 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
            general_config_yaml['impose_bids_format'] = True
        elif self.bids_selected == 'No':
            general_config_yaml['impose_bids_format'] = False
+    
+       general_config_yaml['input_filetype'] = self.file_extension_selected
 
        # TODO Delph : add further modifications to config files as options added to interface
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -803,6 +803,10 @@ class SemiAutoPheToolThresholdWindow(qt.QWidget):
       self.cancelButton.clicked.connect(self.pushCancel)
       layout.addWidget(self.cancelButton)
 
+      self.reference_label = qt.QLabel()
+      self.reference_label.setText('Volbers, B., Staykov, D., Wagner, I., Dörfler, A., Saake, M., Schwab, S., & Bardutzky, J. (2011). Semi-automatic \n volumetric assessment of perihemorrhagic edema with computed tomography. European journal of neurology, \n 18(11), 1323–1328. https://doi.org/10.1111/j.1468-1331.2011.03395.x')
+      layout.addWidget(self.reference_label)
+
       self.setLayout(layout)
       self.setWindowTitle("Semi-automatic PHE Tool")
       self.resize(400, 200)

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -244,18 +244,18 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       self.segmenter = segmenter
       self.reuse_configuration_selected_option = reuse_configuration_selected_option
 
-      self.include_semi_auto_PHE_tool_selected_option = 'Yes' 
-      self.modality_selected = 'CT' 
+      self.include_semi_auto_PHE_tool_selected_option = 'Yes' # TODO remove hardcoded value, take from config
+      self.modality_selected = 'CT' # TODO remove hardcoded value, take from config
       self.include_semi_automatic_PHE_tool_label = qt.QLabel()
       self.include_semi_automatic_PHE_tool_combobox = qt.QComboBox()
-      self.bids_selected = 'Yes'
+      self.bids_selected = 'Yes' # TODO remove hardcoded value, take from config
       self.bids_hbox_label = qt.QLabel()
       self.bids_combobox = qt.QComboBox()
       self.ct_window_level_label = qt.QLabel()
-      self.ct_window_level_selected = '45'
+      self.ct_window_level_selected = '45' # TODO remove hardcoded value, take from config
       self.ct_window_level_line_edit = qt.QLineEdit(self.ct_window_level_selected)
       self.ct_window_width_label = qt.QLabel()
-      self.ct_window_width_selected = '85'
+      self.ct_window_width_selected = '85' # TODO remove hardcoded value, take from config
       self.ct_window_width_line_edit = qt.QLineEdit(self.ct_window_width_selected)
 
       layout = qt.QVBoxLayout()
@@ -266,10 +266,12 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       task_button_hbox_label.setText('Task : ')
       task_button_hbox_label.setStyleSheet("font-weight: bold")
 
+      # TODO add value, take from config
       self.segmentation_task_checkbox = qt.QCheckBox()
       self.segmentation_task_checkbox.setText('Segmentation')
       self.segmentation_task_checkbox.stateChanged.connect(self.segmentation_checkbox_state_changed)
 
+      # TODO add value, take from config
       self.classification_task_checkbox = qt.QCheckBox()
       self.classification_task_checkbox.setText('Classification')
 
@@ -295,8 +297,8 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       self.ct_modality_radio_button.toggled.connect(lambda: self.update_selected_modality(self.ct_modality_radio_button.text))
       self.mri_modality_radio_button.toggled.connect(lambda: self.update_selected_modality(self.mri_modality_radio_button.text))
 
-      self.ct_modality_radio_button.setChecked(True) # par défaut
-      self.modality_selected = self.ct_modality_radio_button.text
+      self.ct_modality_radio_button.setChecked(True) # TODO remove hardcoded value, take from config
+      self.modality_selected = self.ct_modality_radio_button.text # TODO remove hardcoded value, take from config
 
       layout.addLayout(modality_hbox)
 
@@ -305,7 +307,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       self.include_semi_automatic_PHE_tool_label.setText('Include Semi-Automatic PHE Segmentation Tool? ')
       self.include_semi_automatic_PHE_tool_label.setStyleSheet("font-weight: bold")
 
-      self.include_semi_automatic_PHE_tool_combobox.addItem('Yes')
+      self.include_semi_automatic_PHE_tool_combobox.addItem('Yes') # TODO remove hardcoded value, take from config
       self.include_semi_automatic_PHE_tool_combobox.addItem('No')
       self.include_semi_automatic_PHE_tool_combobox.currentIndexChanged.connect(self.update_include_semi_automatic_PHE_tool)
 
@@ -320,7 +322,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       self.bids_hbox_label.setStyleSheet("font-weight: bold")
       bids_hbox.addWidget(self.bids_hbox_label)
 
-      self.bids_combobox.addItem('Yes')
+      self.bids_combobox.addItem('Yes') # TODO remove hardcoded value, take from config
       self.bids_combobox.addItem('No')
 
       self.bids_combobox.currentIndexChanged.connect(self.update_bids)
@@ -336,10 +338,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       file_extension_hbox.addWidget(self.file_extension_label)
 
       self.file_extension_combobox = qt.QComboBox()
-      self.file_extension_combobox.addItem('*.nii.gz')
+      self.file_extension_combobox.addItem('*.nii.gz') # TODO remove hardcoded value, take from config
       self.file_extension_combobox.addItem('*.nrrd')
 
-      self.file_extension_selected = '*.nii.gz'
+      self.file_extension_selected = '*.nii.gz' # TODO remove hardcoded value, take from config
 
       self.file_extension_combobox.currentIndexChanged.connect(self.update_file_extension)
       file_extension_hbox.addWidget(self.file_extension_combobox)
@@ -354,11 +356,11 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       initial_view_hbox.addWidget(self.initial_view_label)
 
       self.initial_view_combobox = qt.QComboBox()
-      self.initial_view_combobox.addItem('Red (axial)')
+      self.initial_view_combobox.addItem('Red (axial)') # TODO remove hardcoded value, take from config
       self.initial_view_combobox.addItem('Yellow (sagittal)')
       self.initial_view_combobox.addItem('Green (coronal)')
 
-      self.initial_view_selected = 'Red (axial)'
+      self.initial_view_selected = 'Red (axial)' # TODO remove hardcoded value, take from config
 
       self.initial_view_combobox.currentIndexChanged.connect(self.update_initial_view)
       initial_view_hbox.addWidget(self.initial_view_combobox)
@@ -373,10 +375,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       interpolate_hbox.addWidget(self.interpolate_label)
 
       self.interpolate_combobox = qt.QComboBox()
-      self.interpolate_combobox.addItem('No')
+      self.interpolate_combobox.addItem('No') # TODO remove hardcoded value, take from config
       self.interpolate_combobox.addItem('Yes')
 
-      self.interpolate_selected = 'No'
+      self.interpolate_selected = 'No' # TODO remove hardcoded value, take from config
 
       self.interpolate_combobox.currentIndexChanged.connect(self.update_interpolate)
       interpolate_hbox.addWidget(self.interpolate_combobox)
@@ -416,7 +418,122 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       # if classification : configure checkboxes, comboboxes, text fields
       # configure keyboard shortcuts
 
+      # TODO Delph : load default values from configuration files instead of hardcoded here 
+      # TODO Delph : for template, select conf file and simply copy content here and data will then be automatically loaded 
+      # TODO Delph : if new configuration, force empty output folder upon selection 
+      # TODO Delph : if template configuration, BE MORE FLEXIBLE (issue #30) allow selection of existing outputFolder with config 
+      # only if the configuration changed superficially (impose_bids : true to false only; not input file ext;
+      #  is_classif || is_segment : true to false only; is_semi_auto : any; not modality; slice_view : any; window: any)
+      # ks : any
+      # labels : any HU range; any color; append at end ; no modif name || value 
+      # classif : append only (AND WORK MUST BE DONE TO REORG PREV DATA TO HAVE EMPTY FIELDS i.e. no mismatch of columns and data in .csv)
+
       ##########################################
+
+      toggle_fill_ks_hbox = qt.QHBoxLayout()
+
+      toggle_fill_ks_label = qt.QLabel()
+      toggle_fill_ks_label.setText('Toggle Fill Keyboard Shortcut : ')
+      toggle_fill_ks_label.setStyleSheet("font-weight: bold")
+      toggle_fill_ks_hbox.addWidget(toggle_fill_ks_label)
+
+      self.toggle_fill_ks_selected = 'f' # TODO remove hardcoded value, take from config
+      self.toggle_fill_ks_line_edit = qt.QLineEdit(self.toggle_fill_ks_selected)
+      self.toggle_fill_ks_line_edit.setMaxLength(1)
+      self.toggle_fill_ks_line_edit.textChanged.connect(self.update_toggle_fill_ks)
+      toggle_fill_ks_hbox.addWidget(self.toggle_fill_ks_line_edit)
+
+      layout.addLayout(toggle_fill_ks_hbox)
+
+      toggle_visibility_ks_hbox = qt.QHBoxLayout()
+
+      toggle_visibility_ks_label = qt.QLabel()
+      toggle_visibility_ks_label.setText('Toggle Visibility Keyboard Shortcut : ')
+      toggle_visibility_ks_label.setStyleSheet("font-weight: bold")
+      toggle_visibility_ks_hbox.addWidget(toggle_visibility_ks_label)
+
+      self.toggle_visibility_ks_selected = 'v' # TODO remove hardcoded value, take from config
+      self.toggle_visibility_ks_line_edit = qt.QLineEdit(self.toggle_visibility_ks_selected)
+      self.toggle_visibility_ks_line_edit.setMaxLength(1)
+      self.toggle_visibility_ks_line_edit.textChanged.connect(self.update_toggle_visibility_ks)
+      toggle_visibility_ks_hbox.addWidget(self.toggle_visibility_ks_line_edit)
+
+      layout.addLayout(toggle_visibility_ks_hbox)
+
+      undo_ks_hbox = qt.QHBoxLayout()
+
+      undo_ks_label = qt.QLabel()
+      undo_ks_label.setText('Undo Keyboard Shortcut : ')
+      undo_ks_label.setStyleSheet("font-weight: bold")
+      undo_ks_hbox.addWidget(undo_ks_label)
+
+      self.undo_ks_selected = 'z' # TODO remove hardcoded value, take from config
+      self.undo_ks_line_edit = qt.QLineEdit(self.undo_ks_selected)
+      self.undo_ks_line_edit.setMaxLength(1)
+      self.undo_ks_line_edit.textChanged.connect(self.update_undo_ks)
+      undo_ks_hbox.addWidget(self.undo_ks_line_edit)
+
+      layout.addLayout(undo_ks_hbox)
+
+      save_seg_ks_hbox = qt.QHBoxLayout()
+
+      save_seg_ks_label = qt.QLabel()
+      save_seg_ks_label.setText('Save Segmentation Keyboard Shortcut : ')
+      save_seg_ks_label.setStyleSheet("font-weight: bold")
+      save_seg_ks_hbox.addWidget(save_seg_ks_label)
+
+      self.save_seg_ks_selected = 's' # TODO remove hardcoded value, take from config
+      self.save_seg_ks_line_edit = qt.QLineEdit(self.save_seg_ks_selected)
+      self.save_seg_ks_line_edit.setMaxLength(1)
+      self.save_seg_ks_line_edit.textChanged.connect(self.update_save_seg_ks)
+      save_seg_ks_hbox.addWidget(self.save_seg_ks_line_edit)
+
+      layout.addLayout(save_seg_ks_hbox)
+
+      smooth_ks_hbox = qt.QHBoxLayout()
+
+      smooth_ks_label = qt.QLabel()
+      smooth_ks_label.setText('Smooth Margins Keyboard Shortcut : ')
+      smooth_ks_label.setStyleSheet("font-weight: bold")
+      smooth_ks_hbox.addWidget(smooth_ks_label)
+
+      self.smooth_ks_selected = 'l' # TODO remove hardcoded value, take from config
+      self.smooth_ks_line_edit = qt.QLineEdit(self.smooth_ks_selected)
+      self.smooth_ks_line_edit.setMaxLength(1)
+      self.smooth_ks_line_edit.textChanged.connect(self.update_smooth_ks)
+      smooth_ks_hbox.addWidget(self.smooth_ks_line_edit)
+
+      layout.addLayout(smooth_ks_hbox)
+
+      remove_small_holes_ks_hbox = qt.QHBoxLayout()
+
+      remove_small_holes_ks_label = qt.QLabel()
+      remove_small_holes_ks_label.setText('Remove Small Holes Keyboard Shortcut : ')
+      remove_small_holes_ks_label.setStyleSheet("font-weight: bold")
+      remove_small_holes_ks_hbox.addWidget(remove_small_holes_ks_label)
+
+      self.remove_small_holes_ks_selected = 'o' # TODO remove hardcoded value, take from config
+      self.remove_small_holes_ks_line_edit = qt.QLineEdit(self.remove_small_holes_ks_selected)
+      self.remove_small_holes_ks_line_edit.setMaxLength(1)
+      self.remove_small_holes_ks_line_edit.textChanged.connect(self.update_remove_small_holes_ks)
+      remove_small_holes_ks_hbox.addWidget(self.remove_small_holes_ks_line_edit)
+
+      layout.addLayout(remove_small_holes_ks_hbox)
+
+      interpolate_ks_hbox = qt.QHBoxLayout()
+
+      interpolate_ks_label = qt.QLabel()
+      interpolate_ks_label.setText('Interpolate Image Keyboard Shortcut : ')
+      interpolate_ks_label.setStyleSheet("font-weight: bold")
+      interpolate_ks_hbox.addWidget(interpolate_ks_label)
+
+      self.interpolate_ks_selected = 'i' # TODO remove hardcoded value, take from config
+      self.interpolate_ks_line_edit = qt.QLineEdit(self.interpolate_ks_selected)
+      self.interpolate_ks_line_edit.setMaxLength(1)
+      self.interpolate_ks_line_edit.textChanged.connect(self.update_interpolate_ks)
+      interpolate_ks_hbox.addWidget(self.interpolate_ks_line_edit)
+
+      layout.addLayout(interpolate_ks_hbox)
 
       self.previous_button = qt.QPushButton('Previous')
       self.previous_button.clicked.connect(self.push_previous)
@@ -441,6 +558,27 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        else: 
             self.include_semi_automatic_PHE_tool_label.setVisible(False)
             self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+   
+   def update_interpolate_ks(self):
+       self.interpolate_ks_selected = self.interpolate_ks_line_edit.text
+   
+   def update_remove_small_holes_ks(self):
+       self.remove_small_holes_ks_selected = self.remove_small_holes_ks_line_edit.text
+   
+   def update_smooth_ks(self):
+       self.smooth_ks_selected = self.smooth_ks_line_edit.text
+
+   def update_save_seg_ks(self):
+       self.save_seg_ks_selected = self.save_seg_ks_line_edit.text
+   
+   def update_undo_ks(self):
+       self.undo_ks_selected = self.undo_ks_line_edit.text
+   
+   def update_toggle_visibility_ks(self):
+       self.toggle_visibility_ks_selected = self.toggle_visibility_ks_line_edit.text
+   
+   def update_toggle_fill_ks(self):
+       self.toggle_fill_ks_selected = self.toggle_fill_ks_line_edit.text
    
    def update_ct_window_width(self):
        self.ct_window_width_selected = self.ct_window_width_line_edit.text
@@ -535,6 +673,14 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
     
        general_config_yaml['ct_window_level'] = int(self.ct_window_level_selected)
        general_config_yaml['ct_window_width'] = int(self.ct_window_width_selected)
+
+       keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][0]['shortcut'] = self.toggle_fill_ks_selected
+       keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][1]['shortcut'] = self.toggle_visibility_ks_selected
+       keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][2]['shortcut'] = self.undo_ks_selected
+       keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][3]['shortcut'] = self.save_seg_ks_selected
+       keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][4]['shortcut'] = self.smooth_ks_selected
+       keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][5]['shortcut'] = self.remove_small_holes_ks_selected
+       keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][6]['shortcut'] = self.interpolate_ks_selected
 
        # TODO Delph : add further modifications to config files as options added to interface
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -340,10 +340,28 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       layout.addLayout(file_extension_hbox)
 
+      initial_view_hbox = qt.QHBoxLayout()
+
+      self.initial_view_label = qt.QLabel()
+      self.initial_view_label.setText('Initial View : ')
+      self.initial_view_label.setStyleSheet("font-weight: bold")
+      initial_view_hbox.addWidget(self.initial_view_label)
+
+      self.initial_view_combobox = qt.QComboBox()
+      self.initial_view_combobox.addItem('Red (axial)')
+      self.initial_view_combobox.addItem('Yellow (sagittal)')
+      self.initial_view_combobox.addItem('Green (coronal)')
+
+      self.initial_view_selected = 'Red (axial)'
+
+      self.initial_view_combobox.currentIndexChanged.connect(self.update_initial_view)
+      initial_view_hbox.addWidget(self.initial_view_combobox)
+
+      layout.addLayout(initial_view_hbox)
+
       ##########################################
       # TODO Delph : create buttons
 
-      # specify initial scan view (sagittal, coronal, axial)
       # specify interpolate 
       # if segmentation : configure labels (if CT : configure thresholds)
       # if classification : configure checkboxes, comboboxes, text fields
@@ -373,6 +391,9 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        else: 
             self.include_semi_automatic_PHE_tool_label.setVisible(False)
             self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+   
+   def update_initial_view(self):
+       self.initial_view_selected = self.initial_view_combobox.currentText
    
    def update_file_extension(self):
        self.file_extension_selected = self.file_extension_combobox.currentText
@@ -430,6 +451,13 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
            general_config_yaml['impose_bids_format'] = False
     
        general_config_yaml['input_filetype'] = self.file_extension_selected
+       
+       if 'Red' in self.initial_view_selected:
+           general_config_yaml['slice_view_color'] = 'Red'
+       elif 'Yellow' in self.initial_view_selected:
+           general_config_yaml['slice_view_color'] = 'Yellow'
+       elif 'Green' in self.initial_view_selected:
+           general_config_yaml['slice_view_color'] = 'Green'
 
        # TODO Delph : add further modifications to config files as options added to interface
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -85,6 +85,7 @@ IS_CLASSIFICATION_REQUESTED = True
 IS_SEGMENTATION_REQUESTED = True
 IS_SEMI_AUTOMATIC_PHE_TOOL_REQUESTED = True
 IS_MOUSE_SHORTCUTS_REQUESTED = False
+IS_KEYBOARD_SHORTCUTS_REQUESTED = True
 
 MODALITY = 'CT'
 
@@ -426,12 +427,23 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       ##########################################
 
+      keyboard_shortcuts_hbox = qt.QHBoxLayout()
+
+      keyboard_shortcuts_label = qt.QLabel('Use Custom Keyboard Shortcuts? ')
+      keyboard_shortcuts_label.setStyleSheet("font-weight: bold")
+      keyboard_shortcuts_hbox.addWidget(keyboard_shortcuts_label)
+
+      self.keyboard_shortcuts_checkbox = qt.QCheckBox()
+      keyboard_shortcuts_hbox.addWidget(self.keyboard_shortcuts_checkbox)
+
+      layout.addLayout(keyboard_shortcuts_hbox)
+
       toggle_fill_ks_hbox = qt.QHBoxLayout()
 
-      toggle_fill_ks_label = qt.QLabel()
-      toggle_fill_ks_label.setText('Toggle Fill Keyboard Shortcut : ')
-      toggle_fill_ks_label.setStyleSheet("font-weight: bold")
-      toggle_fill_ks_hbox.addWidget(toggle_fill_ks_label)
+      self.toggle_fill_ks_label = qt.QLabel()
+      self.toggle_fill_ks_label.setText('Toggle Fill Keyboard Shortcut : ')
+      self.toggle_fill_ks_label.setStyleSheet("font-style: italic")
+      toggle_fill_ks_hbox.addWidget(self.toggle_fill_ks_label)
 
       self.toggle_fill_ks_line_edit = qt.QLineEdit(self.toggle_fill_ks_selected)
       self.toggle_fill_ks_line_edit.setMaxLength(1)
@@ -441,10 +453,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       toggle_visibility_ks_hbox = qt.QHBoxLayout()
 
-      toggle_visibility_ks_label = qt.QLabel()
-      toggle_visibility_ks_label.setText('Toggle Visibility Keyboard Shortcut : ')
-      toggle_visibility_ks_label.setStyleSheet("font-weight: bold")
-      toggle_visibility_ks_hbox.addWidget(toggle_visibility_ks_label)
+      self.toggle_visibility_ks_label = qt.QLabel()
+      self.toggle_visibility_ks_label.setText('Toggle Visibility Keyboard Shortcut : ')
+      self.toggle_visibility_ks_label.setStyleSheet("font-style: italic")
+      toggle_visibility_ks_hbox.addWidget(self.toggle_visibility_ks_label)
 
       self.toggle_visibility_ks_line_edit = qt.QLineEdit(self.toggle_visibility_ks_selected)
       self.toggle_visibility_ks_line_edit.setMaxLength(1)
@@ -454,10 +466,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       undo_ks_hbox = qt.QHBoxLayout()
 
-      undo_ks_label = qt.QLabel()
-      undo_ks_label.setText('Undo Keyboard Shortcut : ')
-      undo_ks_label.setStyleSheet("font-weight: bold")
-      undo_ks_hbox.addWidget(undo_ks_label)
+      self.undo_ks_label = qt.QLabel()
+      self.undo_ks_label.setText('Undo Keyboard Shortcut : ')
+      self.undo_ks_label.setStyleSheet("font-style: italic")
+      undo_ks_hbox.addWidget(self.undo_ks_label)
 
       self.undo_ks_line_edit = qt.QLineEdit(self.undo_ks_selected)
       self.undo_ks_line_edit.setMaxLength(1)
@@ -467,10 +479,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       save_seg_ks_hbox = qt.QHBoxLayout()
 
-      save_seg_ks_label = qt.QLabel()
-      save_seg_ks_label.setText('Save Segmentation Keyboard Shortcut : ')
-      save_seg_ks_label.setStyleSheet("font-weight: bold")
-      save_seg_ks_hbox.addWidget(save_seg_ks_label)
+      self.save_seg_ks_label = qt.QLabel()
+      self.save_seg_ks_label.setText('Save Segmentation Keyboard Shortcut : ')
+      self.save_seg_ks_label.setStyleSheet("font-style: italic")
+      save_seg_ks_hbox.addWidget(self.save_seg_ks_label)
 
       self.save_seg_ks_line_edit = qt.QLineEdit(self.save_seg_ks_selected)
       self.save_seg_ks_line_edit.setMaxLength(1)
@@ -480,10 +492,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       smooth_ks_hbox = qt.QHBoxLayout()
 
-      smooth_ks_label = qt.QLabel()
-      smooth_ks_label.setText('Smooth Margins Keyboard Shortcut : ')
-      smooth_ks_label.setStyleSheet("font-weight: bold")
-      smooth_ks_hbox.addWidget(smooth_ks_label)
+      self.smooth_ks_label = qt.QLabel()
+      self.smooth_ks_label.setText('Smooth Margins Keyboard Shortcut : ')
+      self.smooth_ks_label.setStyleSheet("font-style: italic")
+      smooth_ks_hbox.addWidget(self.smooth_ks_label)
 
       self.smooth_ks_line_edit = qt.QLineEdit(self.smooth_ks_selected)
       self.smooth_ks_line_edit.setMaxLength(1)
@@ -493,10 +505,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       remove_small_holes_ks_hbox = qt.QHBoxLayout()
 
-      remove_small_holes_ks_label = qt.QLabel()
-      remove_small_holes_ks_label.setText('Remove Small Holes Keyboard Shortcut : ')
-      remove_small_holes_ks_label.setStyleSheet("font-weight: bold")
-      remove_small_holes_ks_hbox.addWidget(remove_small_holes_ks_label)
+      self.remove_small_holes_ks_label = qt.QLabel()
+      self.remove_small_holes_ks_label.setText('Remove Small Holes Keyboard Shortcut : ')
+      self.remove_small_holes_ks_label.setStyleSheet("font-style: italic")
+      remove_small_holes_ks_hbox.addWidget(self.remove_small_holes_ks_label)
 
       self.remove_small_holes_ks_line_edit = qt.QLineEdit(self.remove_small_holes_ks_selected)
       self.remove_small_holes_ks_line_edit.setMaxLength(1)
@@ -506,10 +518,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       interpolate_ks_hbox = qt.QHBoxLayout()
 
-      interpolate_ks_label = qt.QLabel()
-      interpolate_ks_label.setText('Interpolate Image Keyboard Shortcut : ')
-      interpolate_ks_label.setStyleSheet("font-weight: bold")
-      interpolate_ks_hbox.addWidget(interpolate_ks_label)
+      self.interpolate_ks_label = qt.QLabel()
+      self.interpolate_ks_label.setText('Interpolate Image Keyboard Shortcut : ')
+      self.interpolate_ks_label.setStyleSheet("font-style: italic")
+      interpolate_ks_hbox.addWidget(self.interpolate_ks_label)
 
       self.interpolate_ks_line_edit = qt.QLineEdit(self.interpolate_ks_selected)
       self.interpolate_ks_line_edit.setMaxLength(1)
@@ -555,6 +567,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
    def connect_buttons_to_callbacks(self):
        self.segmentation_task_checkbox.stateChanged.connect(self.segmentation_checkbox_state_changed)
        self.classification_task_checkbox.stateChanged.connect(self.classification_checkbox_state_changed)
+       self.keyboard_shortcuts_checkbox.stateChanged.connect(self.keyboard_shortcuts_checkbox_state_changed)
        self.ct_modality_radio_button.toggled.connect(lambda: self.update_selected_modality(self.ct_modality_radio_button.text))
        self.mri_modality_radio_button.toggled.connect(lambda: self.update_selected_modality(self.mri_modality_radio_button.text))
        self.include_semi_automatic_PHE_tool_combobox.currentIndexChanged.connect(self.update_include_semi_automatic_PHE_tool)
@@ -611,13 +624,16 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        self.segmentation_task_checkbox.setChecked(self.segmentation_selected)
        self.classification_task_checkbox.setChecked(self.classification_selected)
        self.mouse_shortcuts_checkbox.setChecked(self.mouse_shortcuts_selected)
+       self.keyboard_shortcuts_checkbox.setChecked(self.keyboard_shortcuts_selected)
 
        self.segmentation_checkbox_state_changed()
+       self.keyboard_shortcuts_checkbox_state_changed()
 
    def set_default_values(self):
        self.segmentation_selected = self.general_config_yaml['is_segmentation_requested'] 
        self.classification_selected = self.general_config_yaml['is_classification_requested']
        self.mouse_shortcuts_selected = self.general_config_yaml['is_mouse_shortcuts_requested']
+       self.keyboard_shortcuts_selected = self.general_config_yaml['is_keyboard_shortcuts_requested']
 
        if self.general_config_yaml['is_semi_automatic_phe_tool_requested']:  
             self.include_semi_auto_PHE_tool_selected_option = 'Yes'
@@ -652,6 +668,24 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
    def classification_checkbox_state_changed(self):
        self.classification_selected = self.classification_task_checkbox.isChecked()
        self.configure_classification_button.setEnabled(self.classification_selected)
+
+   def keyboard_shortcuts_checkbox_state_changed(self):
+       self.keyboard_shortcuts_selected = self.keyboard_shortcuts_checkbox.isChecked()
+
+       self.toggle_fill_ks_label.setVisible(self.keyboard_shortcuts_selected)
+       self.toggle_fill_ks_line_edit.setVisible(self.keyboard_shortcuts_selected)
+       self.toggle_visibility_ks_label.setVisible(self.keyboard_shortcuts_selected)
+       self.toggle_visibility_ks_line_edit.setVisible(self.keyboard_shortcuts_selected)
+       self.undo_ks_label.setVisible(self.keyboard_shortcuts_selected)
+       self.undo_ks_line_edit.setVisible(self.keyboard_shortcuts_selected)
+       self.save_seg_ks_label.setVisible(self.keyboard_shortcuts_selected)
+       self.save_seg_ks_line_edit.setVisible(self.keyboard_shortcuts_selected)
+       self.smooth_ks_label.setVisible(self.keyboard_shortcuts_selected)
+       self.smooth_ks_line_edit.setVisible(self.keyboard_shortcuts_selected)
+       self.remove_small_holes_ks_label.setVisible(self.keyboard_shortcuts_selected)
+       self.remove_small_holes_ks_line_edit.setVisible(self.keyboard_shortcuts_selected)
+       self.interpolate_ks_label.setVisible(self.keyboard_shortcuts_selected)
+       self.interpolate_ks_line_edit.setVisible(self.keyboard_shortcuts_selected)
    
    def segmentation_checkbox_state_changed(self):
        self.segmentation_selected = self.segmentation_task_checkbox.isChecked()
@@ -745,6 +779,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        self.general_config_yaml['is_segmentation_requested'] = self.segmentation_task_checkbox.isChecked()
        self.general_config_yaml['is_classification_requested'] = self.classification_task_checkbox.isChecked()
        self.general_config_yaml['is_mouse_shortcuts_requested'] = self.mouse_shortcuts_checkbox.isChecked()
+       self.general_config_yaml['is_keyboard_shortcuts_requested'] = self.keyboard_shortcuts_checkbox.isChecked()
        self.general_config_yaml['modality'] = self.modality_selected
 
        if self.include_semi_auto_PHE_tool_selected_option == 'Yes':
@@ -2146,6 +2181,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         global IS_CLASSIFICATION_REQUESTED
         global IS_SEGMENTATION_REQUESTED
         global IS_MOUSE_SHORTCUTS_REQUESTED
+        global IS_KEYBOARD_SHORTCUTS_REQUESTED
         global IS_SEMI_AUTOMATIC_PHE_TOOL_REQUESTED
         global INTERPOLATE_VALUE
         global CT_WINDOW_WIDTH
@@ -2159,6 +2195,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         IS_CLASSIFICATION_REQUESTED = self.general_config_yaml["is_classification_requested"]
         IS_SEGMENTATION_REQUESTED = self.general_config_yaml["is_segmentation_requested"]
         IS_MOUSE_SHORTCUTS_REQUESTED = self.general_config_yaml["is_mouse_shortcuts_requested"]
+        IS_KEYBOARD_SHORTCUTS_REQUESTED = self.general_config_yaml["is_keyboard_shortcuts_requested"]
         IS_SEMI_AUTOMATIC_PHE_TOOL_REQUESTED = self.general_config_yaml["is_semi_automatic_phe_tool_requested"]
         INTERPOLATE_VALUE = self.general_config_yaml["interpolate_value"]
 
@@ -2325,17 +2362,18 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.UB_HU.setVisible(False)
             self.ui.pushDefaultMin.setVisible(False)
             self.ui.pushDefaultMax.setVisible(False)
-        
-        for i in self.keyboard_config_yaml["KEYBOARD_SHORTCUTS"]:
 
-            shortcutKey = i.get("shortcut")
-            callback_name = i.get("callback")
-            button_name = i.get("button")
+        if self.general_config_yaml['is_keyboard_shortcuts_requested']:
+            for i in self.keyboard_config_yaml["KEYBOARD_SHORTCUTS"]:
 
-            button = getattr(self.ui, button_name)
-            callback = getattr(self, callback_name)
+                shortcutKey = i.get("shortcut")
+                callback_name = i.get("callback")
+                button_name = i.get("button")
 
-            self.connectShortcut(shortcutKey, button, callback)
+                button = getattr(self.ui, button_name)
+                callback = getattr(self, callback_name)
+
+                self.connectShortcut(shortcutKey, button, callback)
         
         # Display the selected color view at module startup
         if self.general_config_yaml['slice_view_color'] == "Yellow":

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -84,6 +84,7 @@ REQUIRE_VOLUME_DATA_HIERARCHY_BIDS_FORMAT = False
 IS_CLASSIFICATION_REQUESTED = True
 IS_SEGMENTATION_REQUESTED = True
 IS_SEMI_AUTOMATIC_PHE_TOOL_REQUESTED = True
+IS_MOUSE_SHORTCUTS_REQUESTED = False
 
 MODALITY = 'CT'
 
@@ -516,6 +517,17 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       layout.addLayout(interpolate_ks_hbox)
 
+      mouse_shortcuts_hbox = qt.QHBoxLayout()
+
+      mouse_shortcuts_label = qt.QLabel('Use Custom Mouse Shortcuts? ')
+      mouse_shortcuts_label.setStyleSheet("font-weight: bold")
+      mouse_shortcuts_hbox.addWidget(mouse_shortcuts_label)
+
+      self.mouse_shortcuts_checkbox = qt.QCheckBox()
+      mouse_shortcuts_hbox.addWidget(self.mouse_shortcuts_checkbox)
+
+      layout.addLayout(mouse_shortcuts_hbox)
+
       self.configure_labels_button = qt.QPushButton('Configure Labels...')
       self.configure_labels_button.setStyleSheet("background-color : yellowgreen")
       layout.addWidget(self.configure_labels_button)
@@ -598,12 +610,14 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
        self.segmentation_task_checkbox.setChecked(self.segmentation_selected)
        self.classification_task_checkbox.setChecked(self.classification_selected)
+       self.mouse_shortcuts_checkbox.setChecked(self.mouse_shortcuts_selected)
 
        self.segmentation_checkbox_state_changed()
 
    def set_default_values(self):
        self.segmentation_selected = self.general_config_yaml['is_segmentation_requested'] 
        self.classification_selected = self.general_config_yaml['is_classification_requested']
+       self.mouse_shortcuts_selected = self.general_config_yaml['is_mouse_shortcuts_requested']
 
        if self.general_config_yaml['is_semi_automatic_phe_tool_requested']:  
             self.include_semi_auto_PHE_tool_selected_option = 'Yes'
@@ -730,6 +744,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
    def push_apply(self):
        self.general_config_yaml['is_segmentation_requested'] = self.segmentation_task_checkbox.isChecked()
        self.general_config_yaml['is_classification_requested'] = self.classification_task_checkbox.isChecked()
+       self.general_config_yaml['is_mouse_shortcuts_requested'] = self.mouse_shortcuts_checkbox.isChecked()
        self.general_config_yaml['modality'] = self.modality_selected
 
        if self.include_semi_auto_PHE_tool_selected_option == 'Yes':
@@ -2106,21 +2121,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # ----- ANW Addition  ----- : Initialize called var to False so the timer only stops once
     self.called = False
     self.called_onLoadSegmentation = False
-
-    # MB
-    self.interactor1 = slicer.app.layoutManager().sliceWidget(
-            'Yellow').sliceView().interactor()
-    self.interactor2 = slicer.app.layoutManager().sliceWidget(
-        'Red').sliceView().interactor()
-
-    # Apply the custom interactor style
-    styleYellow = slicer.app.layoutManager().sliceWidget('Yellow')
-    self.styleYellow = CustomInteractorStyle(sliceWidget=styleYellow)
-    self.interactor1.SetInteractorStyle(self.styleYellow)
-
-    styleRed = slicer.app.layoutManager().sliceWidget('Red')
-    self.styleRed = CustomInteractorStyle(sliceWidget=styleRed)
-    self.interactor2.SetInteractorStyle(self.styleRed)
   
   def get_keyboard_shortcuts_config_values(self):
       with open(KEYBOARD_SHORTCUTS_CONFIG_FILE_PATH, 'r') as file:
@@ -2145,6 +2145,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         global MODALITY
         global IS_CLASSIFICATION_REQUESTED
         global IS_SEGMENTATION_REQUESTED
+        global IS_MOUSE_SHORTCUTS_REQUESTED
         global IS_SEMI_AUTOMATIC_PHE_TOOL_REQUESTED
         global INTERPOLATE_VALUE
         global CT_WINDOW_WIDTH
@@ -2157,6 +2158,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         MODALITY = self.general_config_yaml["modality"]
         IS_CLASSIFICATION_REQUESTED = self.general_config_yaml["is_classification_requested"]
         IS_SEGMENTATION_REQUESTED = self.general_config_yaml["is_segmentation_requested"]
+        IS_MOUSE_SHORTCUTS_REQUESTED = self.general_config_yaml["is_mouse_shortcuts_requested"]
         IS_SEMI_AUTOMATIC_PHE_TOOL_REQUESTED = self.general_config_yaml["is_semi_automatic_phe_tool_requested"]
         INTERPOLATE_VALUE = self.general_config_yaml["interpolate_value"]
 
@@ -2271,6 +2273,22 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.get_keyboard_shortcuts_config_values()
         self.get_classification_config_values()
         self.get_general_config_values()
+
+        if IS_MOUSE_SHORTCUTS_REQUESTED:
+            # MB
+            self.interactor1 = slicer.app.layoutManager().sliceWidget(
+                    'Yellow').sliceView().interactor()
+            self.interactor2 = slicer.app.layoutManager().sliceWidget(
+                'Red').sliceView().interactor()
+
+            # Apply the custom interactor style
+            styleYellow = slicer.app.layoutManager().sliceWidget('Yellow')
+            self.styleYellow = CustomInteractorStyle(sliceWidget=styleYellow)
+            self.interactor1.SetInteractorStyle(self.styleYellow)
+
+            styleRed = slicer.app.layoutManager().sliceWidget('Red')
+            self.styleRed = CustomInteractorStyle(sliceWidget=styleRed)
+            self.interactor2.SetInteractorStyle(self.styleRed)
 
         self.LB_HU = self.label_config_yaml["labels"][0]["lower_bound_HU"]
         self.UB_HU = self.label_config_yaml["labels"][0]["upper_bound_HU"]

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -830,7 +830,7 @@ class ConfigureClassificationWindow(qt.QWidget):
 
       self.setLayout(layout)
       self.setWindowTitle("Configure Classification")
-      self.resize(800, 200)
+      self.resize(300, 600)
 
    def push_remove_checkbox_button(self, checkbox_label):
        self.close()
@@ -890,7 +890,7 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
 
       self.setLayout(layout)
       self.setWindowTitle("Configure Classification Item")
-      self.resize(400, 200)
+      self.resize(200, 100)
    
    def push_save(self):
        current_label_name = self.name_line_edit.text
@@ -914,8 +914,6 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
        configureClassificationWindow = ConfigureClassificationWindow(self.segmenter, self.classification_config_yaml)
        configureClassificationWindow.show()
        self.close()
-
-# TODO Delph : for both classification and label configuration, handle the case when the list is empty
 
 class ConfigureLabelsWindow(qt.QWidget):
    def __init__(self, segmenter, modality, label_config_yaml = None, parent = None):
@@ -1045,11 +1043,22 @@ class ConfigureLabelsWindow(qt.QWidget):
        configureSingleLabelWindow.show()
    
    def push_save(self):
-       with open(LABEL_CONFIG_FILE_PATH, 'w') as file:   
-           yaml.safe_dump(self.label_config_yaml, file)
+       if len(self.label_config_yaml['labels']) == 0:
+            msg = qt.QMessageBox()
+            msg.setWindowTitle('ERROR : Label list is empty')
+            msg.setText('The label list cannot be empty. Using the previous label configuration. ')
+            msg.setStandardButtons(qt.QMessageBox.Ok | qt.QMessageBox.Cancel)
+            msg.buttonClicked.connect(self.push_error_label_list_empty)
+            msg.exec()
+       else:
+            with open(LABEL_CONFIG_FILE_PATH, 'w') as file:   
+                yaml.safe_dump(self.label_config_yaml, file)
 
-       self.close()
+            self.close()
 
+   def push_error_label_list_empty(self):
+       self.push_cancel()
+   
    def push_cancel(self):
        self.close()
 
@@ -2157,6 +2166,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   
   def setupCheckboxes(self, number_of_columns):
       self.checkboxWidgets = {}
+
+      row_index = 0
 
       for i, (objectName, label) in enumerate(self.classification_config_yaml["checkboxes"].items()):
         print(objectName, label)

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -413,6 +413,13 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       # TODO Delph : create buttons
 
       # add button to edit configuration and allow only certain modifications (see previous commit and issue #30)
+      # TODO Delph : if template configuration, BE MORE FLEXIBLE (issue #30) allow selection of existing outputFolder with config 
+      # only if the configuration changed superficially (impose_bids : true to false only; not input file ext;
+      #  is_classif || is_segment : true to false only; is_semi_auto : any; not modality; slice_view : any; window: any)
+      # ks : any
+      # labels : any HU range; any color; append at end ; no modif name || value 
+      # classif : append only (AND WORK MUST BE DONE TO REORG PREV DATA TO HAVE EMPTY FIELDS i.e. no mismatch of columns and data in .csv)
+        
       # create bug for QIntValidator not working anywhere in the file
       # create pull request for issue #30, issue #3, and issue #27 at the same time 
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -215,7 +215,6 @@ class SlicerCARTConfigurationInitialWindow(qt.QWidget):
         slicerCART_configuration_initial_window.show()
         self.close()
    
-   # TODO Delph : validate that the onSelectOutputFile verifyCompatibility is required??? evaluate use cases
    def select_template_folder_clicked(self, button):
        if button.text == 'OK':
           conf_folder_path = qt.QFileDialog.getExistingDirectory(None,"Open a folder", '', qt.QFileDialog.ShowDirsOnly)
@@ -415,14 +414,6 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       # TODO Delph : create buttons
 
       # if classification : configure checkboxes, comboboxes, text fields
-
-      # TODO Delph : if new configuration, force empty output folder upon selection 
-      # TODO Delph : if template configuration, BE MORE FLEXIBLE (issue #30) allow selection of existing outputFolder with config 
-      # only if the configuration changed superficially (impose_bids : true to false only; not input file ext;
-      #  is_classif || is_segment : true to false only; is_semi_auto : any; not modality; slice_view : any; window: any)
-      # ks : any
-      # labels : any HU range; any color; append at end ; no modif name || value 
-      # classif : append only (AND WORK MUST BE DONE TO REORG PREV DATA TO HAVE EMPTY FIELDS i.e. no mismatch of columns and data in .csv)
 
       ##########################################
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -414,6 +414,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       # add button to edit configuration and allow only certain modifications (see previous commit and issue #30)
       # create bug for QIntValidator not working anywhere in the file
+      # create pull request for issue #30, issue #3, and issue #27 at the same time 
 
       ##########################################
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -359,10 +359,27 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       layout.addLayout(initial_view_hbox)
 
+      interpolate_hbox = qt.QHBoxLayout()
+
+      self.interpolate_label = qt.QLabel()
+      self.interpolate_label.setText('Interpolate Image? ')
+      self.interpolate_label.setStyleSheet("font-weight: bold")
+      interpolate_hbox.addWidget(self.interpolate_label)
+
+      self.interpolate_combobox = qt.QComboBox()
+      self.interpolate_combobox.addItem('No')
+      self.interpolate_combobox.addItem('Yes')
+
+      self.interpolate_selected = 'No'
+
+      self.interpolate_combobox.currentIndexChanged.connect(self.update_interpolate)
+      interpolate_hbox.addWidget(self.interpolate_combobox)
+
+      layout.addLayout(interpolate_hbox)
+
       ##########################################
       # TODO Delph : create buttons
-
-      # specify interpolate 
+ 
       # if segmentation : configure labels (if CT : configure thresholds)
       # if classification : configure checkboxes, comboboxes, text fields
 
@@ -391,6 +408,9 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        else: 
             self.include_semi_automatic_PHE_tool_label.setVisible(False)
             self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+   
+   def update_interpolate(self):
+       self.interpolate_selected = self.interpolate_combobox.currentText
    
    def update_initial_view(self):
        self.initial_view_selected = self.initial_view_combobox.currentText
@@ -451,6 +471,11 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
            general_config_yaml['impose_bids_format'] = False
     
        general_config_yaml['input_filetype'] = self.file_extension_selected
+
+       if self.interpolate_selected == 'Yes':
+           general_config_yaml['interpolate_value'] = 1
+       elif self.interpolate_selected == 'No':
+           general_config_yaml['interpolate_value'] = 0
        
        if 'Red' in self.initial_view_selected:
            general_config_yaml['slice_view_color'] = 'Red'

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -250,6 +250,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       task_button_hbox_label = qt.QLabel()
       task_button_hbox_label.setText('Task : ')
+      task_button_hbox_label.setStyleSheet("font-weight: bold")
 
       self.segmentation_task_checkbox = qt.QCheckBox()
       self.segmentation_task_checkbox.setText('Segmentation')
@@ -263,10 +264,30 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       layout.addLayout(task_button_hbox)
 
+      modality_hbox = qt.QHBoxLayout()
+
+      modality_hbox_label = qt.QLabel()
+      modality_hbox_label.setText('Modality : ')
+      modality_hbox_label.setStyleSheet("font-weight: bold")
+
+      self.ct_modality_radio_button = qt.QRadioButton('CT', self)
+      self.mri_modality_radio_button = qt.QRadioButton('MRI', self)
+
+      modality_hbox.addWidget(modality_hbox_label)
+      modality_hbox.addWidget(self.ct_modality_radio_button)
+      modality_hbox.addWidget(self.mri_modality_radio_button)
+
+      self.ct_modality_radio_button.toggled.connect(lambda: self.update_selected_modality(self.ct_modality_radio_button.text))
+      self.mri_modality_radio_button.toggled.connect(lambda: self.update_selected_modality(self.mri_modality_radio_button.text))
+
+      self.ct_modality_radio_button.setChecked(True) # par défaut
+      self.modality_selected = self.ct_modality_radio_button.text
+
+      layout.addLayout(modality_hbox)
+
       ##########################################
       # TODO Delph : create buttons
 
-      # modality combobox
       # if CT and segmentation : ask for semi automatic PHE tool 
       # if MRI : ask for bids 
       # specify initial scan view (sagittal, coronal, axial)
@@ -292,6 +313,9 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       self.setWindowTitle("Configure SlicerCART")
       self.resize(800, 400)
    
+   def update_selected_modality(self, option):
+       self.modality_selected = option
+   
    def push_previous(self):
        slicerCART_configuration_initial_window = SlicerCARTConfigurationInitialWindow(self.segmenter)
        slicerCART_configuration_initial_window.show()
@@ -309,6 +333,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
        general_config_yaml['is_segmentation_requested'] = self.segmentation_task_checkbox.isChecked()
        general_config_yaml['is_classification_requested'] = self.classification_task_checkbox.isChecked()
+       general_config_yaml['modality'] = self.modality_selected
        # TODO Delph : add further modifications to config files as options added to interface
 
        with open(GENERAL_CONFIG_FILE_PATH, 'w') as file:   

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -248,6 +248,9 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       self.modality_selected = 'CT' 
       self.include_semi_automatic_PHE_tool_label = qt.QLabel()
       self.include_semi_automatic_PHE_tool_combobox = qt.QComboBox()
+      self.bids_selected = 'Yes'
+      self.bids_hbox_label = qt.QLabel()
+      self.bids_combobox = qt.QComboBox()
 
       layout = qt.QVBoxLayout()
 
@@ -305,10 +308,24 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       layout.addLayout(self.include_semi_automatic_PHE_tool_hbox)
 
+      bids_hbox = qt.QHBoxLayout()
+
+      self.bids_hbox_label.setText('Impose BIDS ? ')
+      self.bids_hbox_label.setStyleSheet("font-weight: bold")
+      bids_hbox.addWidget(self.bids_hbox_label)
+
+      self.bids_combobox.addItem('Yes')
+      self.bids_combobox.addItem('No')
+
+      self.bids_combobox.currentIndexChanged.connect(self.update_bids)
+      bids_hbox.addWidget(self.bids_combobox)
+
+      layout.addLayout(bids_hbox)
+
       ##########################################
       # TODO Delph : create buttons
 
-      # if MRI : ask for bids
+      # specify file extension to be used
       # specify initial scan view (sagittal, coronal, axial)
       # specify interpolate 
       # if segmentation : configure labels (if CT : configure thresholds)
@@ -340,6 +357,9 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
             self.include_semi_automatic_PHE_tool_label.setVisible(False)
             self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
    
+   def update_bids(self):
+       self.bids_selected = self.bids_combobox.currentText
+   
    def update_include_semi_automatic_PHE_tool(self):
        self.include_semi_auto_PHE_tool_selected_option = self.include_semi_automatic_PHE_tool_combobox.currentText
    
@@ -352,6 +372,13 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        else: 
             self.include_semi_automatic_PHE_tool_label.setVisible(False)
             self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+       
+       if self.modality_selected == 'MRI':
+            self.bids_hbox_label.setVisible(True)
+            self.bids_combobox.setVisible(True)
+       else:
+            self.bids_hbox_label.setVisible(False)
+            self.bids_combobox.setVisible(False)
    
    def push_previous(self):
        slicerCART_configuration_initial_window = SlicerCARTConfigurationInitialWindow(self.segmenter)
@@ -376,6 +403,11 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
            general_config_yaml['is_semi_automatic_phe_tool_requested'] = True 
        elif self.include_semi_auto_PHE_tool_selected_option == 'No':
            general_config_yaml['is_semi_automatic_phe_tool_requested'] = False 
+    
+       if self.bids_selected == 'Yes':
+           general_config_yaml['impose_bids_format'] = True
+       elif self.bids_selected == 'No':
+           general_config_yaml['impose_bids_format'] = False
 
        # TODO Delph : add further modifications to config files as options added to interface
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -380,8 +380,10 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       ##########################################
       # TODO Delph : create buttons
  
+      # if CT : window level and window width 
       # if segmentation : configure labels (if CT : configure thresholds)
       # if classification : configure checkboxes, comboboxes, text fields
+      # configure keyboard shortcuts
 
       ##########################################
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -850,18 +850,18 @@ class ConfigureClassificationWindow(qt.QWidget):
                 self.combobox_table_view.setItem(index, 1, cell)
                 self.combobox_table_view.setHorizontalHeaderItem(1, qt.QTableWidgetItem('Label'))
 
-                options_string = ''
+                combobox = qt.QComboBox()
                 for i, (name, label) in enumerate(combo_box_options.items()):
-                    if options_string == '':
-                        options_string = label
-                    else:
-                        options_string = options_string + '\n' + label
+                    combobox.addItem(label)
 
-                cell = qt.QTableWidgetItem(options_string)
-                cell.setFlags(qt.Qt.NoItemFlags)
-                cell.setForeground(qt.QBrush(qt.QColor(0, 0, 0)))
-                self.combobox_table_view.setItem(index, 2, cell)
-                self.combobox_table_view.setHorizontalHeaderItem(2, qt.QTableWidgetItem('Options'))
+                combobox_hbox = qt.QHBoxLayout()
+                combobox_hbox.addWidget(combobox)
+                combobox_hbox.setAlignment(qt.Qt.AlignCenter)
+                combobox_hbox.setContentsMargins(0, 0, 0, 0)
+                widget = qt.QWidget()
+                widget.setLayout(combobox_hbox)
+                self.combobox_table_view.setCellWidget(index, 2, widget)
+                self.combobox_table_view.setHorizontalHeaderItem(2, qt.QTableWidgetItem(''))
 
       self.add_combobox_button = qt.QPushButton('Add Drop Down')
       self.add_combobox_button.clicked.connect(self.push_add_combobox)
@@ -877,7 +877,7 @@ class ConfigureClassificationWindow(qt.QWidget):
 
       self.setLayout(layout)
       self.setWindowTitle("Configure Classification")
-      self.resize(400, 600)
+      self.resize(500, 600)
 
    def push_remove_combobox_button(self, combo_box_name):
        self.close()

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -246,10 +246,26 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
       layout = qt.QVBoxLayout()
 
+      task_button_hbox = qt.QHBoxLayout()
+
+      task_button_hbox_label = qt.QLabel()
+      task_button_hbox_label.setText('Task : ')
+
+      self.segmentation_task_checkbox = qt.QCheckBox()
+      self.segmentation_task_checkbox.setText('Segmentation')
+
+      self.classification_task_checkbox = qt.QCheckBox()
+      self.classification_task_checkbox.setText('Classification')
+
+      task_button_hbox.addWidget(task_button_hbox_label)
+      task_button_hbox.addWidget(self.segmentation_task_checkbox)
+      task_button_hbox.addWidget(self.classification_task_checkbox)
+
+      layout.addLayout(task_button_hbox)
+
       ##########################################
       # TODO Delph : create buttons
 
-      # task checkboxes : segmentation, classification 
       # modality combobox
       # if CT and segmentation : ask for semi automatic PHE tool 
       # if MRI : ask for bids 
@@ -282,7 +298,27 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        self.close()
    
    def push_apply(self):
-       # TODO Delph : write selected configurations to .yml
+       with open(GENERAL_CONFIG_FILE_PATH, 'r') as file:
+            general_config_yaml = yaml.full_load(file)
+       with open(LABEL_CONFIG_FILE_PATH, 'r') as file:
+            label_config_yaml = yaml.full_load(file)
+       with open(KEYBOARD_SHORTCUTS_CONFIG_FILE_PATH, 'r') as file:
+            keyboard_shortcuts_config_yaml = yaml.full_load(file)
+       with open(CLASSIFICATION_CONFIG_FILE_PATH, 'r') as file:
+            classification_config_yaml = yaml.full_load(file)
+
+       general_config_yaml['is_segmentation_requested'] = self.segmentation_task_checkbox.isChecked()
+       general_config_yaml['is_classification_requested'] = self.classification_task_checkbox.isChecked()
+       # TODO Delph : add further modifications to config files as options added to interface
+
+       with open(GENERAL_CONFIG_FILE_PATH, 'w') as file:   
+            yaml.safe_dump(general_config_yaml, file)
+       with open(LABEL_CONFIG_FILE_PATH, 'w') as file:   
+            yaml.safe_dump(label_config_yaml, file)
+       with open(KEYBOARD_SHORTCUTS_CONFIG_FILE_PATH, 'w') as file:   
+            yaml.safe_dump(keyboard_shortcuts_config_yaml, file)
+       with open(CLASSIFICATION_CONFIG_FILE_PATH, 'w') as file:   
+            yaml.safe_dump(classification_config_yaml, file)
 
        self.segmenter.setup_configuration()
        self.close()

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -1514,7 +1514,7 @@ class ConfigureSingleLabelWindow(qt.QWidget):
                
        if label_found == False:
            # append
-           new_label = copy.deepcopy(self.label_config_yaml['labels'][0])
+           new_label = {'color_b': 10, 'color_g': 10, 'color_r': 255, 'lower_bound_HU': 30, 'name': 'ICH', 'upper_bound_HU': 90, 'value': 1}
            new_label['name'] = self.name_line_edit.text
            new_label['value'] = len(self.label_config_yaml['labels']) + 1
            new_label['color_r'] = int(self.color_r_line_edit.text)

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -2838,8 +2838,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       else:
           return
       
-  def verifyEmpty(self):
-      if self.outputFolder is not None:
+  def verify_empty(self):
+      if self.outputFolder is not None and os.path.exists(self.outputFolder):
 
         content_of_output_folder = os.listdir(self.outputFolder)
         if '.DS_Store' in content_of_output_folder:
@@ -2874,7 +2874,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.outputFolder = qt.QFileDialog.getExistingDirectory(None,"Open a folder", self.DefaultDir, qt.QFileDialog.ShowDirsOnly)
 
       if REQUIRE_EMPTY: 
-          self.verifyEmpty()
+          self.verify_empty()
       
       if self.outputFolder is not None:
           self.ui.LoadClassification.setEnabled(True)

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -2483,7 +2483,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self.general_config_yaml['slice_view_color'] == "Green":
             slicer.app.layoutManager().setLayout(
                 slicer.vtkMRMLLayoutNode.SlicerLayoutOneUpGreenSliceView)
-
+            
+        self.ui.dropDownButton_label_select.clear()
         for label in self.label_config_yaml["labels"]:
             self.ui.dropDownButton_label_select.addItem(label["name"])
   

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -412,8 +412,8 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
       ##########################################
       # TODO Delph : create buttons
 
-      # if classification : configure checkboxes, comboboxes, text fields
-      # create but for QIntValidator not working anywhere in the file
+      # if classification : configure comboboxes, text fields
+      # create bug for QIntValidator not working anywhere in the file
 
       ##########################################
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -593,7 +593,7 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        self.interpolate_combobox.setCurrentIndex(self.interpolate_selected)
 
        self.segmentation_task_checkbox.setChecked(self.segmentation_selected)
-       self.classification_task_checkbox.setChecked(self.segmentation_selected)
+       self.classification_task_checkbox.setChecked(self.classification_selected)
 
        self.segmentation_checkbox_state_changed()
 
@@ -632,20 +632,19 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        self.interpolate_ks_selected = self.keyboard_shortcuts_config_yaml['KEYBOARD_SHORTCUTS'][6]['shortcut'] 
 
    def segmentation_checkbox_state_changed(self):
+       self.segmentation_selected = self.segmentation_task_checkbox.isChecked()
+
        if self.segmentation_task_checkbox.isChecked():
-            self.configure_labels_button.setVisible(True)
+            self.configure_labels_button.setEnabled(True)
 
             if self.modality_selected == 'CT':
-                self.include_semi_automatic_PHE_tool_label.setVisible(True)
-                self.include_semi_automatic_PHE_tool_combobox.setVisible(True)
+                self.include_semi_automatic_PHE_tool_combobox.setEnabled(True)
             else:
-                self.include_semi_automatic_PHE_tool_label.setVisible(False)
-                self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+                self.include_semi_automatic_PHE_tool_combobox.setEnabled(False)
        else: 
-            self.configure_labels_button.setVisible(False)
+            self.configure_labels_button.setEnabled(False)
 
-            self.include_semi_automatic_PHE_tool_label.setVisible(False)
-            self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+            self.include_semi_automatic_PHE_tool_combobox.setEnabled(False)
    
    def update_interpolate_ks(self):
        self.interpolate_ks_selected = self.interpolate_ks_line_edit.text
@@ -696,28 +695,19 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
        self.modality_selected = option
 
        if self.modality_selected == 'CT':
-            self.bids_hbox_label.setVisible(False)
-            self.bids_combobox.setVisible(False)
+            self.bids_combobox.setEnabled(False)
 
-            self.ct_window_level_label.setVisible(True)
-            self.ct_window_level_line_edit.setVisible(True)
-            self.ct_window_width_label.setVisible(True)
-            self.ct_window_width_line_edit.setVisible(True)
+            self.ct_window_level_line_edit.setEnabled(True)
+            self.ct_window_width_line_edit.setEnabled(True)
 
-            if self.segmentation_task_checkbox.isChecked():
-                self.include_semi_automatic_PHE_tool_label.setVisible(True)
-                self.include_semi_automatic_PHE_tool_combobox.setVisible(True)
-            else:
-                self.include_semi_automatic_PHE_tool_label.setVisible(False)
-                self.include_semi_automatic_PHE_tool_combobox.setVisible(False)
+            self.include_semi_automatic_PHE_tool_combobox.setEnabled(self.segmentation_selected)
        else:
-            self.bids_hbox_label.setVisible(True)
-            self.bids_combobox.setVisible(True)
+            self.bids_combobox.setEnabled(True)
 
-            self.ct_window_level_label.setVisible(False)
-            self.ct_window_level_line_edit.setVisible(False)
-            self.ct_window_width_label.setVisible(False)
-            self.ct_window_width_line_edit.setVisible(False)
+            self.ct_window_level_line_edit.setEnabled(False)
+            self.ct_window_width_line_edit.setEnabled(False)
+
+            self.include_semi_automatic_PHE_tool_combobox.setEnabled(False)
    
    def push_configure_labels(self):
        configureLabelsWindow = ConfigureLabelsWindow(self.segmenter, self.modality_selected)
@@ -781,6 +771,8 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
        self.segmenter.setup_configuration()
        self.close()
+
+# TODO Delph LIVE : if cancel label edit, should put the initial labels back... not save to file
 
 class ConfigureLabelsWindow(qt.QWidget):
    def __init__(self, segmenter, modality, parent = None):
@@ -882,6 +874,8 @@ class ConfigureLabelsWindow(qt.QWidget):
       self.resize(800, 200)
 
    def push_edit_button(self, label):
+       self.close()
+
        configureSingleLabelWindow = ConfigureSingleLabelWindow(self.segmenter, self.modality, label)
        configureSingleLabelWindow.show()
 
@@ -950,7 +944,7 @@ class ConfigureSingleLabelWindow(qt.QWidget):
 
       self.value_line_edit = qt.QLineEdit('')
       self.value_line_edit.setValidator(qt.QIntValidator())
-      self.value_line_edit.setReadOnly(True) # To be changed at resolution of Issue #28
+      self.value_line_edit.setEnabled(False) # To be changed at resolution of Issue #28
       value_hbox.addWidget(self.value_line_edit)
       
       layout.addLayout(value_hbox)
@@ -1010,7 +1004,7 @@ class ConfigureSingleLabelWindow(qt.QWidget):
 
       if self.initial_label is not None:
           self.name_line_edit.setText(self.initial_label['name'])
-          self.name_line_edit.setReadOnly(True)
+          self.name_line_edit.setEnabled(False)
           self.value_line_edit.setText(self.initial_label['value'])
           self.color_r_line_edit.setText(label['color_r'])
           self.color_g_line_edit.setText(label['color_g'])

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -871,6 +871,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             INPUT_FILE_EXTENSION = '*.nii.gz'
             # user can decide whether to impose bids or not
             REQUIRE_VOLUME_DATA_HIERARCHY_BIDS_FORMAT = self.general_config_yaml["impose_bids_format"]
+            IS_SEMI_AUTOMATIC_PHE_TOOL_REQUESTED = False
 
 
   def setup(self):
@@ -1006,6 +1007,15 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.SemiAutomaticPHELabel.setVisible(False)
         self.ui.pushButton_SemiAutomaticPHE_Launch.setVisible(False)
         self.ui.pushButton_SemiAutomaticPHE_ShowResult.setVisible(False)
+
+    if MODALITY == 'MRI':
+        self.ui.ThresholdLabel.setVisible(False)
+        self.ui.MinimumLabel.setVisible(False)
+        self.ui.MaximumLabel.setVisible(False)
+        self.ui.LB_HU.setVisible(False)
+        self.ui.UB_HU.setVisible(False)
+        self.ui.pushDefaultMin.setVisible(False)
+        self.ui.pushDefaultMax.setVisible(False)
     
     for i in self.keyboard_config_yaml["KEYBOARD_SHORTCUTS"]:
 
@@ -1017,6 +1027,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         callback = getattr(self, callback_name)
 
         self.connectShortcut(shortcutKey, button, callback)
+  
+  def set_master_volume_intensity_mask_according_to_modality(self):
+      if MODALITY == 'CT':
+            self.segmentEditorNode.SetMasterVolumeIntensityMask(True)
+      elif MODALITY == 'MRI':
+            self.segmentEditorNode.SetMasterVolumeIntensityMask(False)
   
   def setupCheckboxes(self, number_of_columns):
       self.checkboxWidgets = {}
@@ -2233,7 +2249,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Set up the mask parameters (note that PaintAllowed...was changed to EditAllowed)
         self.segmentEditorNode.SetMaskMode(slicer.vtkMRMLSegmentationNode.EditAllowedEverywhere)
         #Set if using Editable intensity range (the range is defined below using object.setParameter)
-        self.segmentEditorNode.SetMasterVolumeIntensityMask(True)
+        self.set_master_volume_intensity_mask_according_to_modality()
         self.segmentEditorNode.SetSourceVolumeIntensityMaskRange(self.LB_HU, self.UB_HU)
         self.segmentEditorNode.SetOverwriteMode(slicer.vtkMRMLSegmentEditorNode.OverwriteAllSegments)
 
@@ -2301,7 +2317,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onLB_HU(self):
       try:
         self.LB_HU=self.ui.LB_HU.value
-        self.segmentEditorNode.SetMasterVolumeIntensityMask(True)
+        self.set_master_volume_intensity_mask_according_to_modality()
         self.segmentEditorNode.SetSourceVolumeIntensityMaskRange(self.LB_HU, self.UB_HU)
         self.label_config_yaml["labels"][self.current_label_index]["lower_bound_HU"] = self.LB_HU
       except:
@@ -2310,7 +2326,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   def onUB_HU(self):
       try:
         self.UB_HU=self.ui.UB_HU.value
-        self.segmentEditorNode.SetMasterVolumeIntensityMask(True)
+        self.set_master_volume_intensity_mask_according_to_modality()
         self.segmentEditorNode.SetSourceVolumeIntensityMaskRange(self.LB_HU, self.UB_HU)
         self.label_config_yaml["labels"][self.current_label_index]["upper_bound_HU"] = self.UB_HU
       except:

--- a/SlicerCART/src/classification_config.yml
+++ b/SlicerCART/src/classification_config.yml
@@ -1,45 +1,40 @@
-# Checkboxes (objectName : name of the checkbox)
 checkboxes:
-  Normal_checkbox: Normal
+  Anoxic_injury_checkbox: Anoxic injury
+  Brain_edema_checkbox: Brain edema
+  Craniectomy_checkbox: Craniectomy
+  Craniotomy_checkbox: Craniotomy
+  EDH_checkbox: EDH
+  EVD_checkbox: EVD
   ICH_checkbox: ICH
   IVH_checkbox: IVH
-  SAH_checkbox: SAH
-  EDH_checkbox: EDH
-  SDH_checkbox: SDH
   Infarct_checkbox: Infarct
   Intra_axial_tumor_checkbox: Intra-axial tumor
   Menigioma_checkbox: Meningioma
-  Multiple_lesions_checkbox: Multiple lesions
-  Brain_edema_checkbox: Brain edema
-  Anoxic_injury_checkbox: Anoxic injury
-  Midline_shift_checkbox: Midline shift
-  Tonsillar_herniation_checkbox: Tonsillar herniation
-  EVD_checkbox: EVD
-  Pressure_monitor_checkbox: Pressure monitor
-  Craniotomy_checkbox: Craniotomy
-  Craniectomy_checkbox: Craniectomy
   Metal_artifact_checkbox: Metal artifact
+  Midline_shift_checkbox: Midline shift
   Motion_artifact_checkbox: Motion artifact
-
-# ComboBoxes (objectName : name of the combobox)
+  Multiple_lesions_checkbox: Multiple lesions
+  Normal_checkbox: Normal
+  Pressure_monitor_checkbox: Pressure monitor
+  SAH_checkbox: SAH
+  SDH_checkbox: SDH
+  Tonsillar_herniation_checkbox: Tonsillar herniation
 comboboxes:
-  atrophy: # Important note: make sure to use underscores to seperate words in names !! (snakecase)
-    atrophy_none: None
+  atrophy:
     atrophy_mild: Mild
     atrophy_moderate: Moderate
+    atrophy_none: None
     atrophy_severe: Severe
-  white_matter_changes:
-    wmc_none: None
-    wmc_mild: Mild
-    wmc_moderate: Moderate
-    wmc_severe: Severe
   ventricular_size:
-    ventricular_size_normal: Normal/proportional
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate
+    ventricular_size_normal: Normal/proportional
     ventricular_size_severe: Severe
-
-# Free text (objectName : name of the text field)
-freetextboxes: 
-  number_of_focal_points: Number of focal points 
+  white_matter_changes:
+    wmc_mild: Mild
+    wmc_moderate: Moderate
+    wmc_none: None
+    wmc_severe: Severe
+freetextboxes:
+  number_of_focal_points: Number of focal points
   other_comments: Comments

--- a/SlicerCART/src/general_config.yml
+++ b/SlicerCART/src/general_config.yml
@@ -1,18 +1,12 @@
-input_filetype: '*.nii.gz' # '*.nrrd' or '*.nii.gz'
-
-default_volume_directory: ''
-default_segmentation_directory: ''
-
-modality: 'CT' # 'CT' or 'MRI'
-slice_view_color: 'Red' # 'Red' or 'Yellow' or 'Green'
-
-interpolate_value: 1
-
-impose_bids_format: False
-
-is_classification_requested: True
-is_segmentation_requested: True
-is_semi_automatic_phe_tool_requested: True
-
-ct_window_width: 85
 ct_window_level: 45
+ct_window_width: 85
+default_segmentation_directory: ''
+default_volume_directory: ''
+impose_bids_format: false
+input_filetype: '*.nii.gz'
+interpolate_value: 1
+is_classification_requested: true
+is_segmentation_requested: false
+is_semi_automatic_phe_tool_requested: true
+modality: CT
+slice_view_color: Red

--- a/SlicerCART/src/general_config.yml
+++ b/SlicerCART/src/general_config.yml
@@ -6,6 +6,7 @@ impose_bids_format: false
 input_filetype: '*.nii.gz'
 interpolate_value: 1
 is_classification_requested: true
+is_mouse_shortcuts_requested: false
 is_segmentation_requested: false
 is_semi_automatic_phe_tool_requested: true
 modality: CT

--- a/SlicerCART/src/general_config.yml
+++ b/SlicerCART/src/general_config.yml
@@ -6,6 +6,7 @@ impose_bids_format: false
 input_filetype: '*.nii.gz'
 interpolate_value: 1
 is_classification_requested: true
+is_keyboard_shortcuts_requested: true
 is_mouse_shortcuts_requested: false
 is_segmentation_requested: false
 is_semi_automatic_phe_tool_requested: true

--- a/SlicerCART/src/keyboard_shortcuts_config.yml
+++ b/SlicerCART/src/keyboard_shortcuts_config.yml
@@ -1,22 +1,22 @@
 KEYBOARD_SHORTCUTS:
-  - button: "pushButton_ToggleFill"
-    callback: "toggleFillButton"
-    shortcut: "f"
-  - button: "pushButton_ToggleVisibility"
-    callback: "onPushButton_ToggleVisibility"
-    shortcut: "v"
-  - button: "pushButton_undo"
-    callback: "onPushButton_undo"
-    shortcut: "z"
-  - button: "SaveSegmentationButton"
-    callback: "onSaveSegmentationButton"
-    shortcut: "s"
-  - button: "pushButton_Smooth"
-    callback: "onPushButton_Smooth"
-    shortcut: "l"
-  - button: "pushButton_Small_holes"
-    callback: "onPushButton_Small_holes"
-    shortcut: "o"
-  - button: "pushButton_Interpolate"
-    callback: "onPushButton_Interpolate"
-    shortcut: "i"
+- button: pushButton_ToggleFill
+  callback: toggleFillButton
+  shortcut: f
+- button: pushButton_ToggleVisibility
+  callback: onPushButton_ToggleVisibility
+  shortcut: v
+- button: pushButton_undo
+  callback: onPushButton_undo
+  shortcut: z
+- button: SaveSegmentationButton
+  callback: onSaveSegmentationButton
+  shortcut: s
+- button: pushButton_Smooth
+  callback: onPushButton_Smooth
+  shortcut: l
+- button: pushButton_Small_holes
+  callback: onPushButton_Small_holes
+  shortcut: o
+- button: pushButton_Interpolate
+  callback: onPushButton_Interpolate
+  shortcut: i

--- a/SlicerCART/src/label_config.yml
+++ b/SlicerCART/src/label_config.yml
@@ -1,22 +1,22 @@
 labels:
-  - name: "ICH"
-    value: 1
-    color_r: 255
-    color_g: 10
-    color_b: 10
-    lower_bound_HU: 30
-    upper_bound_HU: 90
-  - name: "IVH"
-    value: 2
-    color_r: 230
-    color_g: 230
-    color_b: 70
-    lower_bound_HU: 30
-    upper_bound_HU: 90
-  - name: "PHE"
-    value: 3
-    color_r: 11
-    color_g: 80
-    color_b: 255
-    lower_bound_HU: 5
-    upper_bound_HU: 33
+- color_b: 10
+  color_g: 10
+  color_r: 255
+  lower_bound_HU: 30
+  name: ICH
+  upper_bound_HU: 90
+  value: 1
+- color_b: 70
+  color_g: 230
+  color_r: 230
+  lower_bound_HU: 30
+  name: IVH
+  upper_bound_HU: 90
+  value: 2
+- color_b: 255
+  color_g: 80
+  color_r: 11
+  lower_bound_HU: 5
+  name: PHE
+  upper_bound_HU: 33
+  value: 3

--- a/SlicerCART/src/resources/UI/SlicerCART.ui
+++ b/SlicerCART/src/resources/UI/SlicerCART.ui
@@ -244,6 +244,13 @@
       </item>
       <item row="0" column="0" colspan="2">
        <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+         <widget class="QPushButton" name="EditConfiguration">
+          <property name="text">
+           <string>Edit SlicerCART Configuration</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <widget class="QPushButton" name="SelectVolumeFolder">
           <property name="text">


### PR DESCRIPTION
Fixes #3 : added a GUI to configure SlicerCART with the options to create a new configuration or create a new configuration from a template _conf folder (both require an empty output folder), or to continue working in an already configured output folder

Fixes #27 : adapted the painting tools to the selected modality (CT vs MRI)

Fixes #30 : now allows modification of SlicerCART configuration according to preset rules i.e. cannot modify modality, task, input file extension, etc. cannot remove labels or change name / value of label, cannot remove classification item

Fixes #45 and #46 : add possibility to configure whether or not to use the keyboard shortcuts or the mouse shortcuts
