### PR TITLE
Fixes error - installation bug

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -7,7 +7,9 @@
 ###############################################################################
 # Those imports are required to make the module working appropriately using
 # separated files
-from utils import * # Import all modules, packages and global variables
+from utils.requirements import * # Import all modules and packages
+from utils.global_variables import * # Import all global variables
+
 from scripts import * # Import all classes
 
 ###############################################################################

--- a/SlicerCART/src/utils/install_python_packages.py
+++ b/SlicerCART/src/utils/install_python_packages.py
@@ -1,5 +1,3 @@
-import qt
-import slicer
 # TODO: There is probably a more elegant way to install pacakages through the
 #  extension manager when the user installs the extension.
 # TODO: check if the package installed with error
@@ -13,7 +11,6 @@ REQUIRED_PYTHON_PACKAGES = {
     "slicerio": "slicerio",
     "bids_validator": "bids_validator"
 }
-
 
 def check_and_install_python_packages():
     missing_packages = []

--- a/SlicerCART/src/utils/install_python_packages.py
+++ b/SlicerCART/src/utils/install_python_packages.py
@@ -1,4 +1,5 @@
-
+import qt
+import slicer
 # TODO: There is probably a more elegant way to install pacakages through the
 #  extension manager when the user installs the extension.
 # TODO: check if the package installed with error

--- a/SlicerCART/src/utils/requirements.py
+++ b/SlicerCART/src/utils/requirements.py
@@ -3,7 +3,16 @@
 import os
 import logging
 import slicer
-import qt
+
+# Qt installation may lead the module to fail.
+try:
+    print('try import qt.')
+    import qt
+except ImportError:
+    print('import qt failed. PLEASE VERIFY QT INSTALLATION INTO 3D SLICER '
+          'BEFORE ANY FURTHER USE..')
+    #ToDo: add code to install Qt on all operating systems
+
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 from glob import glob


### PR DESCRIPTION
Tested on 5.2.2

Previously, if Slicer was installed on a PC without these modules:

`REQUIRED_PYTHON_PACKAGES = {
    "nibabel": "nibabel",
    "pandas": "pandas",
    "PyYAML": "yaml",
    "pynrrd": "nrrd",
    "slicerio": "slicerio",
    "bids_validator": "bids_validator"
}`

SlicerCART would prompt the user to install them through popup windows that require Qt and Slicer. Because of code fragmentation, `import qt` and `import slicer` were ommited in `install_python_packages.py`, which did not allow the popups to be even created, resulting in a failure to launch SlicerCART.

I've been told that there are bugs related to Qt stalling testing, does this resolve the most important one until now?
