### PR TITLE
Fixes 67 Windowing does not work and suggestion to use min-max instead of level-width #67

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -465,6 +465,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         return is_structure_valid
 
+  @enter_function
   def updateCaseAll(self):
       # All below is dependent on self.currentCase_index updates, 
       self.currentCase = self.Cases[self.currentCase_index]
@@ -478,6 +479,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.ui.SlicerDirectoryListView.setCurrentItem(self.ui.SlicerDirectoryListView.item(self.currentCase_index))
       self.update_current_segmentation_status()
 
+  @enter_function
   def update_current_segmentation_status(self):
       current_color = self.ui.SlicerDirectoryListView.currentItem().foreground().color()
       if current_color == qt.QColor('black'):
@@ -519,6 +521,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.ui.CurrentPath.setReadOnly(True)
       self.ui.CurrentPath.setText(self.currentCasePath)
       
+  @enter_function
   def loadPatient(self):
       timer_index = 0
       self.timers = []
@@ -542,8 +545,10 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # print(' node', self.VolumeNode)
 
       Vol_displayNode.AutoWindowLevelOff()
-      Vol_displayNode.SetWindow(CT_WINDOW_WIDTH)
-      Vol_displayNode.SetLevel(CT_WINDOW_LEVEL)
+      if MODALITY == 'CT':
+          Debug.print(self, 'MODALITY==CT')
+          Vol_displayNode.SetWindow(CT_WINDOW_WIDTH)
+          Vol_displayNode.SetLevel(CT_WINDOW_LEVEL)
       Vol_displayNode.SetInterpolate(INTERPOLATE_VALUE)
       self.newSegmentation()
 
@@ -1430,6 +1435,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       compareSegmentVersionsWindow = CompareSegmentVersionsWindow(self, segmentationInformation_df)
       compareSegmentVersionsWindow.show()
 
+  @enter_function
   def compareSegmentVersions(self, selected_label, selected_version_file_paths):
       self.labelOfCompareSegmentVersions = selected_label
       self.colorsSelectedVersionFilePathsForCompareSegmentVersions = {}
@@ -1445,8 +1451,10 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       
       Vol_displayNode = self.VolumeNode.GetDisplayNode()
       Vol_displayNode.AutoWindowLevelOff()
-      Vol_displayNode.SetWindow(CT_WINDOW_WIDTH)
-      Vol_displayNode.SetLevel(CT_WINDOW_LEVEL)
+      if MODALITY == 'CT':
+          Debug.print(self, 'MODALITY==CT')
+          Vol_displayNode.SetWindow(CT_WINDOW_WIDTH)
+          Vol_displayNode.SetLevel(CT_WINDOW_LEVEL)
       Vol_displayNode.SetInterpolate(INTERPOLATE_VALUE)
 
       self.segmentEditorWidget = slicer.modules.segmenteditor.widgetRepresentation().self().editor

--- a/SlicerCART/src/utils/debugging_helpers.py
+++ b/SlicerCART/src/utils/debugging_helpers.py
@@ -35,11 +35,13 @@ class Debug:
             for element in dictionary:
                 print(f"{name} {element}: ", dictionary[element])
 
-    def print(self, statement='', ):
+    def print(self, statement=''):
         """
         Prints out a statement only if debugging mode is enabled. Allows to
         keep print statement in the code without contaminating the python
         console for non-debugging usage.
+        Usage: Debug.print(self, statement) where statement is a string of a
+        statement the user wants to print only if debugging is enabled.
         """
         if ENABLE_DEBUG:
             print(statement)


### PR DESCRIPTION
This PR fixes issue [67](https://github.com/neuropoly/slicer-manual-annotation/issues/67) Windowing does not work and suggestion to use min-max instead of level-width #67.

To address after [PR 108](https://github.com/neuropoly/slicer-manual-annotation/pull/108) has been addressed.