### PR TITLE
Fixes issue 121 Save segmentation is not robust for versioning

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -645,10 +645,11 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   
   @enter_function
   def updateCurrentOutputPathAndCurrentVolumeFilename(self):
-      if self.currentCasePath == None or self.CurrentFolder == None or self.outputFolder == None:
+      if (self.currentCasePath == None
+              or self.CurrentFolder == None
+              or self.outputFolder == None):
           return
-      
-      print('ase path folder and output are not none! ')
+
       i = 0
       relativePath = ''
       for c in self.currentCasePath:
@@ -656,15 +657,14 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
               relativePath = relativePath + c
           i = i + 1
 
-      print('relative path: ', relativePath)
-
-      self.currentOutputPath = os.path.split(self.outputFolder + relativePath)[0]
-      self.currentVolumeFilename = os.path.split(self.outputFolder + relativePath)[1].split(".")[0]
-      print('self currentoutput path: ', self.currentOutputPath)
-      print('self currentVolumeFilename: ', self.currentVolumeFilename)
+      self.currentOutputPath = (
+          os.path.split(self.outputFolder + relativePath))[0]
+      self.currentVolumeFilename = (
+          os.path.split(self.outputFolder + relativePath)[1].split("."))[0]
   
 
-  # Getter method to get the segmentation node name    - Not sure if this is really useful here. 
+  # Getter method to get the segmentation node name
+  # - Not sure if this is really useful here.
   @property
   def segmentationNodeName(self):
     return f"{os.path.split(self.currentCasePath)[1].split('.')[0]}_segmentation"
@@ -922,8 +922,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   @enter_function
   def createFolders(self):
       self.revision_step = self.ui.RevisionStep.currentText
-      print('self revision step', self.revision_step)
-      print('len self reivisoi step', len(self.revision_step))
       if len(self.revision_step) != 0:
           if os.path.exists(self.outputFolder) == False:
                 msgboxtime = qt.QMessageBox()
@@ -931,7 +929,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 msgboxtime.exec()
           else:
                 self.updateCurrentOutputPathAndCurrentVolumeFilename()
-
 
                 if os.path.exists(self.currentOutputPath) == False:
                     os.makedirs(self.currentOutputPath)
@@ -1091,7 +1088,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Make sure to select the first segmentation node
       # (i.e. the one that was created when the module was loaded,
       # not the one created when the user clicked on the "Load mask" button)
-      self.segmentationNode = slicer.util.getNodesByClass('vtkMRMLSegmentationNode')[0]
+      self.segmentationNode = (
+          slicer.util.getNodesByClass('vtkMRMLSegmentationNode'))[0]
 
       currentSegmentationVersion = self.getCurrentSegmentationVersion()
 
@@ -1367,34 +1365,13 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           version = f'{version}{next_version_number:02d}'
 
       return version 
-  
-  # @enter_function
-  # def getCurrentSegmentationVersion(self):
-  #     list_of_segmentation_filenames = glob(f'{self.currentOutputPath}{os.sep}{INPUT_FILE_EXTENSION}')
-  #
-  #     version = 'v'
-  #     if list_of_segmentation_filenames == []:
-  #         version = version + "01"
-  #     else:
-  #         existing_versions = [(int)(filename.split('_v')[1].split(".")[0]) for filename in list_of_segmentation_filenames]
-  #
-  #         print('existing version: ', existing_versions)
-  #
-  #         next_version_number =  max(existing_versions) + 1
-  #         next_version_number = min(next_version_number, 99) # max 99 versions
-  #         version = f'{version}{next_version_number:02d}'
-  #     return version
+
   @enter_function
   def getCurrentSegmentationVersion(self):
-      # list_of_segmentation_filenames = glob(
-      #     f'{self.currentOutputPath}{os.sep}{INPUT_FILE_EXTENSION}')
+      # Adjust the version according to each individual file.
       list_of_segmentation_filenames = glob(
-          f'{self.currentOutputPath}{os.sep}{self.currentVolumeFilename}{INPUT_FILE_EXTENSION}')
-      print('list of segmentaiton filenames,: ', list_of_segmentation_filenames)
-
-      jac = glob(
-          f'{self.currentOutputPath}{os.sep}{self.currentVolumeFilename}{INPUT_FILE_EXTENSION}')
-      print('jac', jac)
+          f'{self.currentOutputPath}{os.sep}'
+          f'{self.currentVolumeFilename}{INPUT_FILE_EXTENSION}')
 
       version = 'v'
       if list_of_segmentation_filenames == []:
@@ -1402,9 +1379,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       else:
           existing_versions = [(int)(filename.split('_v')[1].split(".")[0]) for
                                filename in list_of_segmentation_filenames]
-
-          print('existing version: ', existing_versions)
-
           next_version_number = max(existing_versions) + 1
           next_version_number = min(next_version_number, 99)  # max 99 versions
           version = f'{version}{next_version_number:02d}'

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -643,10 +643,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       self.updateCurrentOutputPathAndCurrentVolumeFilename()
   
+  @enter_function
   def updateCurrentOutputPathAndCurrentVolumeFilename(self):
       if self.currentCasePath == None or self.CurrentFolder == None or self.outputFolder == None:
           return
       
+      print('ase path folder and output are not none! ')
       i = 0
       relativePath = ''
       for c in self.currentCasePath:
@@ -654,8 +656,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
               relativePath = relativePath + c
           i = i + 1
 
+      print('relative path: ', relativePath)
+
       self.currentOutputPath = os.path.split(self.outputFolder + relativePath)[0]
       self.currentVolumeFilename = os.path.split(self.outputFolder + relativePath)[1].split(".")[0]
+      print('self currentoutput path: ', self.currentOutputPath)
+      print('self currentVolumeFilename: ', self.currentVolumeFilename)
   
 
   # Getter method to get the segmentation node name    - Not sure if this is really useful here. 
@@ -913,8 +919,11 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
               timer.stop()
           timer_index = timer_index + 1
             
+  @enter_function
   def createFolders(self):
       self.revision_step = self.ui.RevisionStep.currentText
+      print('self revision step', self.revision_step)
+      print('len self reivisoi step', len(self.revision_step))
       if len(self.revision_step) != 0:
           if os.path.exists(self.outputFolder) == False:
                 msgboxtime = qt.QMessageBox()
@@ -922,6 +931,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 msgboxtime.exec()
           else:
                 self.updateCurrentOutputPathAndCurrentVolumeFilename()
+
 
                 if os.path.exists(self.currentOutputPath) == False:
                     os.makedirs(self.currentOutputPath)
@@ -1038,6 +1048,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       return label_string, data_string
   
+  @enter_function
   def cast_segmentation_to_uint8(self):
       for case in self.predictions_paths:
           # Load the segmentation
@@ -1077,7 +1088,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Create folders if not exist
       self.createFolders()
       
-      # Make sure to select the first segmentation node  (i.e. the one that was created when the module was loaded, not the one created when the user clicked on the "Load mask" button)
+      # Make sure to select the first segmentation node
+      # (i.e. the one that was created when the module was loaded,
+      # not the one created when the user clicked on the "Load mask" button)
       self.segmentationNode = slicer.util.getNodesByClass('vtkMRMLSegmentationNode')[0]
 
       currentSegmentationVersion = self.getCurrentSegmentationVersion()
@@ -1193,6 +1206,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       return next_case_name
 
+  @enter_function
   def qualityControlOfLabels(self):
       is_valid = True 
 
@@ -1354,16 +1368,45 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       return version 
   
+  # @enter_function
+  # def getCurrentSegmentationVersion(self):
+  #     list_of_segmentation_filenames = glob(f'{self.currentOutputPath}{os.sep}{INPUT_FILE_EXTENSION}')
+  #
+  #     version = 'v'
+  #     if list_of_segmentation_filenames == []:
+  #         version = version + "01"
+  #     else:
+  #         existing_versions = [(int)(filename.split('_v')[1].split(".")[0]) for filename in list_of_segmentation_filenames]
+  #
+  #         print('existing version: ', existing_versions)
+  #
+  #         next_version_number =  max(existing_versions) + 1
+  #         next_version_number = min(next_version_number, 99) # max 99 versions
+  #         version = f'{version}{next_version_number:02d}'
+  #     return version
+  @enter_function
   def getCurrentSegmentationVersion(self):
-      list_of_segmentation_filenames = glob(f'{self.currentOutputPath}{os.sep}{INPUT_FILE_EXTENSION}')
-      
+      # list_of_segmentation_filenames = glob(
+      #     f'{self.currentOutputPath}{os.sep}{INPUT_FILE_EXTENSION}')
+      list_of_segmentation_filenames = glob(
+          f'{self.currentOutputPath}{os.sep}{self.currentVolumeFilename}{INPUT_FILE_EXTENSION}')
+      print('list of segmentaiton filenames,: ', list_of_segmentation_filenames)
+
+      jac = glob(
+          f'{self.currentOutputPath}{os.sep}{self.currentVolumeFilename}{INPUT_FILE_EXTENSION}')
+      print('jac', jac)
+
       version = 'v'
       if list_of_segmentation_filenames == []:
           version = version + "01"
       else:
-          existing_versions = [(int)(filename.split('_v')[1].split(".")[0]) for filename in list_of_segmentation_filenames]
-          next_version_number =  max(existing_versions) + 1
-          next_version_number = min(next_version_number, 99) # max 99 versions
+          existing_versions = [(int)(filename.split('_v')[1].split(".")[0]) for
+                               filename in list_of_segmentation_filenames]
+
+          print('existing version: ', existing_versions)
+
+          next_version_number = max(existing_versions) + 1
+          next_version_number = min(next_version_number, 99)  # max 99 versions
           version = f'{version}{next_version_number:02d}'
       return version
       
@@ -1450,6 +1493,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       else:
           Debug.print(self, 'No output folder selected.')
 
+  @enter_function
   def update_case_list_colors(self):
       if self.outputFolder is None or self.CurrentFolder is None:
           return


### PR DESCRIPTION
This PR:
Adjust the version number according to each file instead of increasing version according to all files in the folder.
This overcomes the limitation of having a maximum 99 files in the same folder to having now a maximum of 99 versions per file.


Previously:
sub-007004/anat/file1_v01.nii.gz
sub-007004/anat/otherFile_v02.nii.gz
sub-007004/anat/file1_v03.nii.gz

Now:
sub-007004/anat/file1_v01.nii.gz
sub-007004/anat/otherFile_v01.nii.gz
sub-007004/anat/file1_v02.nii.gz

HOW TO TEST?
Save multiple versions for a single or multiple files.
