### PR TITLE
Fixes 131 Modify Classification labels prevent saving an existing project 

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -934,6 +934,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.toggleStartTimerButton() 
 
 
+  @enter_function
   def resetClassificationInformation(self):
         # Try/Except to prevent crashing when selecting another file in the
         # UI case list if no classification_config_yaml file is already created.
@@ -950,87 +951,330 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         
   
+  # @enter_function
+  # def getClassificationInformation(self):
+  #     self.outputClassificationInformationFile = (
+  #         os.path.join(self.currentOutputPath,
+  #                      '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename)))
+  #     header = None
+  #     if os.path.exists(self.outputClassificationInformationFile) and os.path.isfile(self.outputClassificationInformationFile):
+  #           with open(self.outputClassificationInformationFile, 'r') as f:
+  #               header = f.readlines()[0]
+  #
+  #     label_string = ""
+  #     data_string = ""
+  #
+  #     if header is not None:
+  #
+  #         print('header not none', header)
+  #         label_string = header.split('time,')[1]
+  #         labels = label_string.split(',')
+  #
+  #         number_of_checkboxes = len(self.config_yaml["checkboxes"].items())
+  #         number_of_comboboxes = len(self.config_yaml["comboboxes"].items())
+  #         number_of_freetextboxes = len(
+  #             self.config_yaml["freetextboxes"].items())
+  #
+  #         for i, label in enumerate(labels):
+  #             data = ""
+  #             if '\n' in label:
+  #                 label = label.replace('\n', '')
+  #             if 0 <= i < number_of_checkboxes:
+  #                 for _, (objectName, checkbox_label) in enumerate(
+  #                         self.config_yaml["checkboxes"].items()):
+  #                     if label == checkbox_label:
+  #                         data = "No"
+  #                         if self.checkboxWidgets[objectName].isChecked():
+  #                             data = "Yes"
+  #             elif (number_of_checkboxes <= i < number_of_checkboxes +
+  #                   number_of_comboboxes):
+  #                 for _, (comboBoxName, options) in enumerate(
+  #                         self.config_yaml["comboboxes"].items()):
+  #                     combobox_label = comboBoxName.replace("_",
+  #                                                           " ").capitalize()
+  #                     if label == combobox_label:
+  #                         data = self.comboboxWidgets[comboBoxName].currentText
+  #             elif (number_of_checkboxes + number_of_comboboxes <= i <
+  #                   number_of_checkboxes + number_of_comboboxes +
+  #                   number_of_freetextboxes):
+  #                 for _, (freeTextBoxObjectName, free_text_label) in enumerate(
+  #                         self.config_yaml["freetextboxes"].items()):
+  #                     if label == free_text_label:
+  #                         data = self.freeTextBoxes[
+  #                             freeTextBoxObjectName].text.replace("\n", " // ")
+  #
+  #             if i > 0:
+  #                 data_string = data_string + ","
+  #             data_string = data_string + data
+  #
+  #     else:
+  #         print('in elase get classificaiton info')
+  #
+  #         print('self config yaml checkbos', self.config_yaml["checkboxes"])
+  #
+  #         for i, (objectName, label) in enumerate(
+  #                 self.config_yaml["checkboxes"].items()):
+  #             if label_string != "":
+  #                 label_string = label_string + ","
+  #                 data_string = data_string + ","
+  #
+  #             label_string = label_string + label
+  #
+  #             data = "No"
+  #             if self.checkboxWidgets[objectName].isChecked():
+  #                 data = "Yes"
+  #
+  #             data_string = data_string + data
+  #
+  #         for i, (comboBoxName, options) in enumerate(
+  #                 self.config_yaml["comboboxes"].items()):
+  #             label = comboBoxName.replace("_", " ").capitalize()
+  #
+  #             if label_string != "":
+  #                 label_string = label_string + ","
+  #                 data_string = data_string + ","
+  #
+  #             label_string = label_string + label
+  #
+  #     data = self.comboboxWidgets[comboBoxName].currentText
+  #     data_string = data_string + data
+  #
+  #     for i, (freeTextBoxObjectName, label) in enumerate(
+  #             self.config_yaml["freetextboxes"].items()):
+  #         if label_string != "":
+  #             label_string = label_string + ","
+  #             data_string = data_string + ","
+  #
+  #         label_string = label_string + label
+  #
+  #         data = self.freeTextBoxes[freeTextBoxObjectName].text.replace("\n",
+  #                                                                       " // ")
+  #         data_string = data_string + data
+  #
+  #     return label_string, data_string
+
+  @enter_function
   def getClassificationInformation(self):
-      self.outputClassificationInformationFile = os.path.join(self.currentOutputPath,
-                                            '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
+      self.outputClassificationInformationFile = (
+          os.path.join(self.currentOutputPath,
+                       '{}_ClassificationInformation.csv'.format(
+                           self.currentVolumeFilename)))
       header = None
-      if os.path.exists(self.outputClassificationInformationFile) and os.path.isfile(self.outputClassificationInformationFile):
-            with open(self.outputClassificationInformationFile, 'r') as f:
-                header = f.readlines()[0]
-    
+      if os.path.exists(
+              self.outputClassificationInformationFile) and os.path.isfile(
+              self.outputClassificationInformationFile):
+          with open(self.outputClassificationInformationFile, 'r') as f:
+              header = f.readlines()[0]
+
       label_string = ""
       data_string = ""
 
       if header is not None:
-            label_string = header.split('time,')[1]
 
-            labels = label_string.split(',')
+          print('header not none', header)
+          label_string = header.split('time,')[1]
+          labels = label_string.split(',')
 
-            number_of_checkboxes = len(self.config_yaml["checkboxes"].items())
-            number_of_comboboxes = len(self.config_yaml["comboboxes"].items())
-            number_of_freetextboxes = len(self.config_yaml["freetextboxes"].items())
+          number_of_checkboxes = len(self.config_yaml["checkboxes"].items())
+          number_of_comboboxes = len(self.config_yaml["comboboxes"].items())
+          number_of_freetextboxes = len(
+              self.config_yaml["freetextboxes"].items())
 
-            for i, label in enumerate(labels):
-                data = ""
-                if '\n' in label:
-                    label = label.replace('\n', '')
-                if 0 <= i < number_of_checkboxes:
-                    for _, (objectName, checkbox_label) in enumerate(self.config_yaml["checkboxes"].items()):
-                        if label == checkbox_label:
-                            data = "No"
-                            if self.checkboxWidgets[objectName].isChecked():
-                                data = "Yes"
-                elif number_of_checkboxes <= i < number_of_checkboxes + number_of_comboboxes:
-                    for _, (comboBoxName, options) in enumerate(self.config_yaml["comboboxes"].items()):
-                        combobox_label = comboBoxName.replace("_", " ").capitalize()
-                        if label == combobox_label:
-                            data = self.comboboxWidgets[comboBoxName].currentText
-                elif number_of_checkboxes + number_of_comboboxes <= i < number_of_checkboxes + number_of_comboboxes + number_of_freetextboxes:
-                    for _, (freeTextBoxObjectName, free_text_label) in enumerate(self.config_yaml["freetextboxes"].items()):
-                        if label == free_text_label:
-                            data = self.freeTextBoxes[freeTextBoxObjectName].text.replace("\n", " // ")
+          for i, label in enumerate(labels):
+              data = ""
+              if '\n' in label:
+                  label = label.replace('\n', '')
+              if 0 <= i < number_of_checkboxes:
+                  for _, (objectName, checkbox_label) in enumerate(
+                          self.config_yaml["checkboxes"].items()):
+                      if label == checkbox_label:
+                          data = "No"
+                          if self.checkboxWidgets[objectName].isChecked():
+                              data = "Yes"
+              elif (number_of_checkboxes <= i < number_of_checkboxes +
+                    number_of_comboboxes):
+                  for _, (comboBoxName, options) in enumerate(
+                          self.config_yaml["comboboxes"].items()):
+                      combobox_label = comboBoxName.replace("_",
+                                                            " ").capitalize()
+                      if label == combobox_label:
+                          data = self.comboboxWidgets[comboBoxName].currentText
+              elif (number_of_checkboxes + number_of_comboboxes <= i <
+                    number_of_checkboxes + number_of_comboboxes +
+                    number_of_freetextboxes):
+                  for _, (freeTextBoxObjectName, free_text_label) in enumerate(
+                          self.config_yaml["freetextboxes"].items()):
+                      if label == free_text_label:
+                          data = self.freeTextBoxes[
+                              freeTextBoxObjectName].text.replace("\n", " // ")
 
-                if i > 0:
-                    data_string = data_string + ","
-                data_string = data_string + data
+              if i > 0:
+                  data_string = data_string + ","
+              data_string = data_string + data
 
       else:
-            for i, (objectName, label) in enumerate(self.config_yaml["checkboxes"].items()):
-                if label_string != "":
-                    label_string = label_string + ","
-                    data_string = data_string + ","
-                
-                label_string = label_string + label
-                
-                data = "No"
-                if self.checkboxWidgets[objectName].isChecked():
-                    data = "Yes"
-                
-                data_string = data_string + data
-            
-            for i, (comboBoxName, options) in enumerate(self.config_yaml["comboboxes"].items()):
-                label = comboBoxName.replace("_", " ").capitalize()
+          print('in elase get classificaiton info')
 
-                if label_string != "":
-                    label_string = label_string + ","
-                    data_string = data_string + ","
-                
-                label_string = label_string + label
+          print('self config yaml checkbos', self.config_yaml["checkboxes"])
+          label_string = {}
+          data_string = {}
 
-                data = self.comboboxWidgets[comboBoxName].currentText
-                data_string = data_string + data
-            
-            for i, (freeTextBoxObjectName, label) in enumerate(self.config_yaml["freetextboxes"].items()):
-                if label_string != "":
-                    label_string = label_string + ","
-                    data_string = data_string + ","
-                
-                label_string = label_string + label
-                
-                data = self.freeTextBoxes[freeTextBoxObjectName].text.replace("\n", " // ")
-                data_string = data_string + data
+          list_of_boxes = ["checkboxes", "comboboxes", "freetextboxes"]
+          for element in list_of_boxes:
+              # label_string, data_string = self.build_classification_labels()
+              label_temp, data_temp = self.build_classification_labels(element)
+
+              label_string.update(label_temp)
+              data_string.update(data_temp)
+
+              print('checkboxe label and data string', label_string,
+                    '\n', data_string)
+
+          print('succed adding checkbox', label_string,
+                    '\n', data_string)
+
+          # for element in
+
+          # for i, (objectName, label) in enumerate(
+          #         self.config_yaml["checkboxes"].items()):
+          #
+          #     print('i', i)
+          #     print('objectname', objectName)
+          #     print('label111', label)
+          #     maxime = {label: "checkboxes"}
+          #
+          #     print('string to save', )
+          #
+          #
+          #     if label_string != "":
+          #         label_string = label_string + ","
+          #         data_string = data_string + ","
+          #
+          #     print('label_stirng', label_string)
+          #
+          #     label_string = label_string + label
+          #
+          #     data = "No"
+          #     if self.checkboxWidgets[objectName].isChecked():
+          #         data = "Yes"
+          #
+          #     data_string = data_string + data
+
+          # for i, (comboBoxName, options) in enumerate(
+          #         self.config_yaml["comboboxes"].items()):
+          #     label = comboBoxName.replace("_", " ").capitalize()
+          #
+          #     if label_string != "":
+          #         label_string = label_string + ","
+          #         data_string = data_string + ","
+          #
+          #     label_string = label_string + label
+      #
+      # data = self.comboboxWidgets[comboBoxName].currentText
+      # data_string = data_string + data
+      #
+      # for i, (freeTextBoxObjectName, label) in enumerate(
+      #         self.config_yaml["freetextboxes"].items()):
+      #     if label_string != "":
+      #         label_string = label_string + ","
+      #         data_string = data_string + ","
+      #
+      #     label_string = label_string + label
+      #
+      #     data = self.freeTextBoxes[freeTextBoxObjectName].text.replace("\n",
+      #                                                                   " // ")
+      #     data_string = data_string + data
 
       return label_string, data_string
+
+  @enter_function
+  def build_classification_labels(self, classif_label):
+      header_dict = {}
+      value_dict = {}
+
+      for i, (objectName, label) in enumerate(
+              self.config_yaml[classif_label].items()):
+
+          local_header_dict = {}
+
+          print('i', i)
+          print('objectname', objectName)
+          print('label111', label)
+          # maxime = {label: classif_label}
+          # print('maxime ', maxime)
+
+
+          # local_header_dict[f"{label}"] = classif_label
+
+          if classif_label == "checkboxes":
+              local_header_dict[label] = classif_label
+              data = "No"
+              if self.checkboxWidgets[objectName].isChecked():
+                  data = "Yes"
+              print('data', data)
+
+          elif classif_label == "comboboxes":
+
+              local_header_dict[objectName] = classif_label
+
+
+              data = self.comboboxWidgets[objectName].currentText
+              print('data')
+
+          elif classif_label == "freetextboxes":
+              local_header_dict[label] = classif_label
+              data = self.freeTextBoxes[objectName].text.replace(
+                  "\n", " // ")
+
+
+          header_dict[f"{local_header_dict}"] = classif_label
+
+
+
+
+      # for i, (comboBoxName, options) in enumerate(
+      #         self.config_yaml["comboboxes"].items()):
+      #     label = comboBoxName.replace("_", " ").capitalize()
+      #
+      #     if label_string != "":
+      #         label_string = label_string + ","
+      #         data_string = data_string + ","
+      #
+      #     label_string = label_string + label
+
+
+          # print('string to save', )
+          #
+          # if label_string != "":
+          #     label_string = label_string + ","
+          #     data_string = data_string + ","
+          #
+          # print('label_stirng', label_string)
+          #
+          # label_string = label_string + label
+
+
+
+
+          value_dict[f"{local_header_dict}"] = data
+
+          print('value dict local', value_dict)
+
+          # header_dict[label] = "checkboxes"
+
+
+      # header_dict = ",".join(header_dict)
+      print('string header dict', header_dict)
+      # value_dict = ",".join(value_dict.values())
+      print('string value dict', value_dict)
+
+      return header_dict, value_dict
+
+
+
+          # data_string = data_string + data
+
+
   
   @enter_function
   def cast_segmentation_to_uint8(self):
@@ -1316,31 +1560,103 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             f.write(tag_str + "\n")
             f.write(data_str + "\n")
         
-  def saveClassificationInformation(self, classification_information_labels_string, classification_information_data_string):
-        currentClassificationInformationVersion = self.getClassificationInformationVersion()
+  # @enter_function
+  # def saveClassificationInformation(self, classification_information_labels_string, classification_information_data_string):
+  #       currentClassificationInformationVersion = self.getClassificationInformationVersion()
+  #
+  #       tag_str = "Volume filename,Classification version,Annotator Name,Annotator degree,Revision step,Date and time"
+  #       tag_str = tag_str + "," + classification_information_labels_string
+  #
+  #       data_str = self.currentCase
+  #       data_str = data_str + "," + currentClassificationInformationVersion
+  #       data_str = data_str + "," + self.annotator_name
+  #       data_str = data_str + "," + self.annotator_degree
+  #       data_str = data_str + "," + self.revision_step[0]
+  #       data_str = data_str + "," + datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+  #       data_str = data_str + "," + classification_information_data_string
+  #
+  #       self.outputClassificationInformationFile = os.path.join(self.currentOutputPath,
+  #                                           '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
+  #       if not os.path.isfile(self.outputClassificationInformationFile):
+  #           with open(self.outputClassificationInformationFile, 'w') as f:
+  #               f.write(tag_str)
+  #               f.write("\n")
+  #               f.write(data_str)
+  #       else:
+  #           with open(self.outputClassificationInformationFile, 'a') as f:
+  #               f.write("\n")
+  #               f.write(data_str)
 
-        tag_str = "Volume filename,Classification version,Annotator Name,Annotator degree,Revision step,Date and time" 
-        tag_str = tag_str + "," + classification_information_labels_string
-        
-        data_str = self.currentCase 
-        data_str = data_str + "," + currentClassificationInformationVersion
-        data_str = data_str + "," + self.annotator_name
-        data_str = data_str + "," + self.annotator_degree
-        data_str = data_str + "," + self.revision_step[0]
-        data_str = data_str + "," + datetime.today().strftime('%Y-%m-%d %H:%M:%S')
-        data_str = data_str + "," + classification_information_data_string
-        
-        self.outputClassificationInformationFile = os.path.join(self.currentOutputPath,
-                                            '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
-        if not os.path.isfile(self.outputClassificationInformationFile):
-            with open(self.outputClassificationInformationFile, 'w') as f:
-                f.write(tag_str)
-                f.write("\n")
-                f.write(data_str)
-        else:
-            with open(self.outputClassificationInformationFile, 'a') as f:
-                f.write("\n")
-                f.write(data_str)
+  # @enter_function
+  # def saveClassificationInformation(self,
+  #                                   classification_information_labels_string,
+  #                                   classification_information_data_string):
+  #     currentClassificationInformationVersion = self.getClassificationInformationVersion()
+  #
+  #     tag_str = "Volume filename,Classification version,Annotator Name,Annotator degree,Revision step,Date and time"
+  #     tag_str = tag_str + "," + classification_information_labels_string
+  #
+  #     data_str = self.currentCase
+  #     data_str = data_str + "," + currentClassificationInformationVersion
+  #     data_str = data_str + "," + self.annotator_name
+  #     data_str = data_str + "," + self.annotator_degree
+  #     data_str = data_str + "," + self.revision_step[0]
+  #     data_str = data_str + "," + datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+  #     data_str = data_str + "," + classification_information_data_string
+  #
+  #     self.outputClassificationInformationFile = os.path.join(
+  #         self.currentOutputPath,
+  #         '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
+  #     if not os.path.isfile(self.outputClassificationInformationFile):
+  #         with open(self.outputClassificationInformationFile, 'w') as f:
+  #             f.write(tag_str)
+  #             f.write("\n")
+  #             f.write(data_str)
+  #     else:
+  #         with open(self.outputClassificationInformationFile, 'a') as f:
+  #             f.write("\n")
+  #             f.write(data_str)
+  @enter_function
+  def saveClassificationInformation(self,
+                                    classification_information_labels_string,
+                                    classification_information_data_string):
+      currentClassificationInformationVersion = self.getClassificationInformationVersion()
+
+      tag_str = "Volume filename,Classification version,Annotator Name,Annotator degree,Revision step,Date and time"
+
+      classification_information_labels_string = ",".join(
+          classification_information_labels_string.keys())
+
+      tag_str = tag_str + "," + classification_information_labels_string
+
+      data_str = self.currentCase
+      data_str = data_str + "," + currentClassificationInformationVersion
+      data_str = data_str + "," + self.annotator_name
+      data_str = data_str + "," + self.annotator_degree
+      data_str = data_str + "," + self.revision_step[0]
+      data_str = data_str + "," + datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+      # data_str = data_str + "," + classification_information_data_string #
+      # need to modify classificaiton information dat string
+
+      self.outputClassificationInformationFile = os.path.join(
+          self.currentOutputPath,
+          '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
+      if not os.path.isfile(self.outputClassificationInformationFile):
+          with open(self.outputClassificationInformationFile, 'w') as f:
+              f.write(tag_str)
+              f.write("\n")
+
+              classification_information_data_string = ",".join(
+                  classification_information_data_string.values())
+
+              print('classificiton information data frstin')
+
+              data_str = data_str + "," + classification_information_data_string
+              f.write(data_str)
+      else:
+          with open(self.outputClassificationInformationFile, 'a') as f:
+              f.write("\n")
+              f.write(data_str)
   
   def getClassificationInformationVersion(self):
       version = "v"
@@ -1514,7 +1830,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       else:
           return
 
-  def onLoadClassification(self): 
+  @enter_function
+  def onLoadClassification(self):
       classificationInformationPath = f'{self.currentOutputPath}{os.sep}{self.currentVolumeFilename}_ClassificationInformation.csv'
       classificationInformation_df = None
       if os.path.exists(classificationInformationPath):
@@ -1531,16 +1848,23 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       loadClassificationWindow = LoadClassificationWindow(self, classificationInformation_df)
       loadClassificationWindow.show()
 
+  @enter_function
   def onSaveClassificationButton(self):
       self.annotator_name = self.ui.Annotator_name.text
       self.annotator_degree = self.ui.AnnotatorDegree.currentText
 
-      classification_information_labels_string, classification_information_data_string = self.getClassificationInformation()
+      classification_information_labels_string, classification_information_data_string \
+          = self.getClassificationInformation()
       
       # Create folders if don't exist
       self.createFolders()
 
-      if self.annotator_name is not None: 
+      if self.annotator_name is not None:
+
+          print(' save class no none classif ino label string', classification_information_labels_string)
+          print('\n\nclassificaitno information label data string',
+                classification_information_data_string)
+
           self.saveClassificationInformation(classification_information_labels_string, classification_information_data_string)
           msg_box = qt.QMessageBox()
           msg_box.setWindowTitle("Success")

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -1750,6 +1750,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           msg_box.setText("Classification saved successfully!")
           msg_box.exec()
 
+
       else:
           msgboxtime = qt.QMessageBox()
           msgboxtime.setText("Classification not saved : no annotator name !  \n Please save again with your name!")

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -513,12 +513,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.set_patient(remaining_list_first)
       self.update_ui()
 
-
-
-
-
-
-
   def validateBIDS(self, path):
         validator = BIDSValidator()
         is_structure_valid = True
@@ -955,112 +949,15 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         except:
             pass
 
-        
-  
-  # @enter_function
-  # def getClassificationInformation(self):
-  #     self.outputClassificationInformationFile = (
-  #         os.path.join(self.currentOutputPath,
-  #                      '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename)))
-  #     header = None
-  #     if os.path.exists(self.outputClassificationInformationFile) and os.path.isfile(self.outputClassificationInformationFile):
-  #           with open(self.outputClassificationInformationFile, 'r') as f:
-  #               header = f.readlines()[0]
-  #
-  #     label_string = ""
-  #     data_string = ""
-  #
-  #     if header is not None:
-  #
-  #         print('header not none', header)
-  #         label_string = header.split('time,')[1]
-  #         labels = label_string.split(',')
-  #
-  #         number_of_checkboxes = len(self.config_yaml["checkboxes"].items())
-  #         number_of_comboboxes = len(self.config_yaml["comboboxes"].items())
-  #         number_of_freetextboxes = len(
-  #             self.config_yaml["freetextboxes"].items())
-  #
-  #         for i, label in enumerate(labels):
-  #             data = ""
-  #             if '\n' in label:
-  #                 label = label.replace('\n', '')
-  #             if 0 <= i < number_of_checkboxes:
-  #                 for _, (objectName, checkbox_label) in enumerate(
-  #                         self.config_yaml["checkboxes"].items()):
-  #                     if label == checkbox_label:
-  #                         data = "No"
-  #                         if self.checkboxWidgets[objectName].isChecked():
-  #                             data = "Yes"
-  #             elif (number_of_checkboxes <= i < number_of_checkboxes +
-  #                   number_of_comboboxes):
-  #                 for _, (comboBoxName, options) in enumerate(
-  #                         self.config_yaml["comboboxes"].items()):
-  #                     combobox_label = comboBoxName.replace("_",
-  #                                                           " ").capitalize()
-  #                     if label == combobox_label:
-  #                         data = self.comboboxWidgets[comboBoxName].currentText
-  #             elif (number_of_checkboxes + number_of_comboboxes <= i <
-  #                   number_of_checkboxes + number_of_comboboxes +
-  #                   number_of_freetextboxes):
-  #                 for _, (freeTextBoxObjectName, free_text_label) in enumerate(
-  #                         self.config_yaml["freetextboxes"].items()):
-  #                     if label == free_text_label:
-  #                         data = self.freeTextBoxes[
-  #                             freeTextBoxObjectName].text.replace("\n", " // ")
-  #
-  #             if i > 0:
-  #                 data_string = data_string + ","
-  #             data_string = data_string + data
-  #
-  #     else:
-  #         print('in elase get classificaiton info')
-  #
-  #         print('self config yaml checkbos', self.config_yaml["checkboxes"])
-  #
-  #         for i, (objectName, label) in enumerate(
-  #                 self.config_yaml["checkboxes"].items()):
-  #             if label_string != "":
-  #                 label_string = label_string + ","
-  #                 data_string = data_string + ","
-  #
-  #             label_string = label_string + label
-  #
-  #             data = "No"
-  #             if self.checkboxWidgets[objectName].isChecked():
-  #                 data = "Yes"
-  #
-  #             data_string = data_string + data
-  #
-  #         for i, (comboBoxName, options) in enumerate(
-  #                 self.config_yaml["comboboxes"].items()):
-  #             label = comboBoxName.replace("_", " ").capitalize()
-  #
-  #             if label_string != "":
-  #                 label_string = label_string + ","
-  #                 data_string = data_string + ","
-  #
-  #             label_string = label_string + label
-  #
-  #     data = self.comboboxWidgets[comboBoxName].currentText
-  #     data_string = data_string + data
-  #
-  #     for i, (freeTextBoxObjectName, label) in enumerate(
-  #             self.config_yaml["freetextboxes"].items()):
-  #         if label_string != "":
-  #             label_string = label_string + ","
-  #             data_string = data_string + ","
-  #
-  #         label_string = label_string + label
-  #
-  #         data = self.freeTextBoxes[freeTextBoxObjectName].text.replace("\n",
-  #                                                                       " // ")
-  #         data_string = data_string + data
-  #
-  #     return label_string, data_string
 
   @enter_function
   def getClassificationInformation(self):
+      """
+      Get all classification information available from both existing csv
+      file and from the current SlicerCART module. Then, update all
+      information available to an updated dataframe.
+      return: dataframe with all previous and actual classification labels.
+      """
       self.outputClassificationInformationFile = (
           os.path.join(self.currentOutputPath,
                        '{}_ClassificationInformation.csv'.format(
@@ -1075,256 +972,64 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       data_string_slicer = ""
 
       if df is not None:
-
-          print('header not none', )
+          # Means that classification csv file already exists.
+          Debug.print(self, 'Classification csv file already exists. To '
+                            'update.')
 
           # Get Slicer Classification data only
           label_string_slicer, data_string_slicer = (
               self.get_classif_config_data())
           Debug.print(self, 'Got classification details from Slicer.')
-          print('header from slicer', label_string_slicer)
-          print(' data from slicer', data_string_slicer)
-
-
-          print('\n\ndf before adding columns', df)
 
           # Add Slicer Classification data header to csv df
           df = self.add_missing_columns_to_df(df, label_string_slicer)
-          print('conten with new columns\n\n', df)
-
-          # Check if any columns in actual classification labels has been
-          # removed, and add -- if the column that has been removed
-
-
           # Extract column names into a dictionary
           columns_dict = self.extract_header_from_df(df)
-          print('columns dic to chek', columns_dict)
-
-          # columns_dict = {i: col for i, col in enumerate(df.columns)}
-          # print('columns_dict', columns_dict)
 
           # Extract previous data into a dictionary
           data_dict = {col: df[col].tolist() for col in df.columns}
-          print('data_dict', data_dict)
 
-          print()
 
+          # Update classification data with annotation information (e.g.
+          # annotator names, degree, revision step, etc.)
           data_string_slicer.update(self.build_current_classif_dictionary())
-          print('data_string slicer updated', data_string_slicer)
+
+          # Check if any columns in actual classification labels has been
+          # removed, and add -- if the column that has been removed
           data_string_slicer = (
               self.add_mark_for_removed_columns(df,  data_string_slicer))
-          print('data stirng slicer updated', data_string_slicer)
 
-
-
-          # print('data string slicer,', data_string_slicer)
+          # Ensure each element of the dictionary is ready to be converted in df
           data_string_slicer = (
               self.convert_string_values_to_list_element(data_string_slicer))
-          print('listed data string slicer', data_string_slicer)
 
-          #Previous dict and new dict should have the same format
-          # Combine the dictionaries
+          # At this point, previous dict and new dict should have the same
+          # format: combine the dictionaries
           combined_df = self.combine_dict(data_dict, data_string_slicer)
-
-          print('\n\n\ncombined dic', combined_df)
-          # Convert to DataFrame
           df = combined_df
-          # df = pd.DataFrame(combined_dict)
-          print('df combined', df)
-          # df = df.fillna("--") ## a la place = ajouter les -- lorsque ajoute
-          # les colonnes nouvelles ou ancienne!
-          print('df with -', df)
-          Debug.df_file(self, df, self.outputFolder)
-
-
-
-          # ## replace na values by --
-          #
-          #
-          # # Add current classification data tp previous data dict
-          #
-          # label_string = columns_dict
-          # data_string = data_dict
-          #
-          # # Update df with actual data
-          # # Add the new row to the DataFrame
-          # df = pd.concat([df, pd.DataFrame([data_string])], ignore_index=True)
-          #
-          # # Convert back df the data
-          # # Convert DataFrame to dictionary
-          # data_string = df.to_dict(orient="list")
-          #
-          # # Make blank cell with --
-
-
-
-
-
-          # label_string = {}
-          # data_string = {}
-          #
-          # list_of_boxes = ["checkboxes", "comboboxes", "freetextboxes"]
-          # for element in list_of_boxes:
-          #     # label_string, data_string = self.build_classification_labels()
-          #     label_temp, data_temp = self.build_classification_labels(element)
-          #
-          #     label_string.update(label_temp)
-          #     data_string.update(data_temp)
-          #
-          #     print('checkboxe label and data string', label_string,
-          #           '\n', data_string)
-          #
-          # print('succed adding checkbox in header not none', label_string,
-          #       '\n', data_string)
-
-
-
-          # label_string = header.split('time,')[1]
-          # labels = label_string.split(',')
-          #
-          # number_of_checkboxes = len(self.config_yaml["checkboxes"].items())
-          # number_of_comboboxes = len(self.config_yaml["comboboxes"].items())
-          # number_of_freetextboxes = len(
-          #     self.config_yaml["freetextboxes"].items())
-          #
-          # for i, label in enumerate(labels):
-          #     data = ""
-          #     if '\n' in label:
-          #         label = label.replace('\n', '')
-          #     if 0 <= i < number_of_checkboxes:
-          #         for _, (objectName, checkbox_label) in enumerate(
-          #                 self.config_yaml["checkboxes"].items()):
-          #             if label == checkbox_label:
-          #                 data = "No"
-          #                 if self.checkboxWidgets[objectName].isChecked():
-          #                     data = "Yes"
-          #     elif (number_of_checkboxes <= i < number_of_checkboxes +
-          #           number_of_comboboxes):
-          #         for _, (comboBoxName, options) in enumerate(
-          #                 self.config_yaml["comboboxes"].items()):
-          #             combobox_label = comboBoxName.replace("_",
-          #                                                   " ").capitalize()
-          #             if label == combobox_label:
-          #                 data = self.comboboxWidgets[comboBoxName].currentText
-          #     elif (number_of_checkboxes + number_of_comboboxes <= i <
-          #           number_of_checkboxes + number_of_comboboxes +
-          #           number_of_freetextboxes):
-          #         for _, (freeTextBoxObjectName, free_text_label) in enumerate(
-          #                 self.config_yaml["freetextboxes"].items()):
-          #             if label == free_text_label:
-          #                 data = self.freeTextBoxes[
-          #                     freeTextBoxObjectName].text.replace("\n", " // ")
-          #
-          #     if i > 0:
-          #         data_string = data_string + ","
-          #     data_string = data_string + data
 
       else:
-          print('in elase get classificaiton info')
-
-          print('self config yaml checkbos', self.config_yaml["checkboxes"])
+          # Classification csv file does not exist already.
           label_string, data_string = self.get_classif_config_data()
-
-          print('label string', label_string)
-          print('data string', data_string)
-
           info_dict = self.build_current_classif_dictionary()
-          print('data_str', info_dict)
 
           data_dict = {}
           data_dict.update(info_dict)
-          print('firt succe', data_dict)
           data_dict.update(data_string)
-          print('data dict', data_dict)
 
+          # Ensure dictionary is ready to be converted to df
           data_dict = self.convert_string_values_to_list_element(data_dict)
-
-          print('final data', data_dict)
           df = pd.DataFrame(data_dict)
-
-          print('df1231231', df )
 
       return df
 
-
-
-
-
-
-
-
-          # label_string = {}
-          # data_string = {}
-          #
-          # list_of_boxes = ["checkboxes", "comboboxes", "freetextboxes"]
-          # for element in list_of_boxes:
-          #     # label_string, data_string = self.build_classification_labels()
-          #     label_temp, data_temp = self.build_classification_labels(element)
-          #
-          #     label_string.update(label_temp)
-          #     data_string.update(data_temp)
-          #
-          #     print('checkboxe label and data string', label_string,
-          #           '\n', data_string)
-          #
-          # print('succed adding checkbox', label_string,
-          #           '\n', data_string)
-
-          # for element in
-
-          # for i, (objectName, label) in enumerate(
-          #         self.config_yaml["checkboxes"].items()):
-          #
-          #     print('i', i)
-          #     print('objectname', objectName)
-          #     print('label111', label)
-          #     maxime = {label: "checkboxes"}
-          #
-          #     print('string to save', )
-          #
-          #
-          #     if label_string != "":
-          #         label_string = label_string + ","
-          #         data_string = data_string + ","
-          #
-          #     print('label_stirng', label_string)
-          #
-          #     label_string = label_string + label
-          #
-          #     data = "No"
-          #     if self.checkboxWidgets[objectName].isChecked():
-          #         data = "Yes"
-          #
-          #     data_string = data_string + data
-
-          # for i, (comboBoxName, options) in enumerate(
-          #         self.config_yaml["comboboxes"].items()):
-          #     label = comboBoxName.replace("_", " ").capitalize()
-          #
-          #     if label_string != "":
-          #         label_string = label_string + ","
-          #         data_string = data_string + ","
-          #
-          #     label_string = label_string + label
-      #
-      # data = self.comboboxWidgets[comboBoxName].currentText
-      # data_string = data_string + data
-      #
-      # for i, (freeTextBoxObjectName, label) in enumerate(
-      #         self.config_yaml["freetextboxes"].items()):
-      #     if label_string != "":
-      #         label_string = label_string + ","
-      #         data_string = data_string + ","
-      #
-      #     label_string = label_string + label
-      #
-      #     data = self.freeTextBoxes[freeTextBoxObjectName].text.replace("\n",
-      #                                                                   " // ")
-      #     data_string = data_string + data
-
-      # return label_string, data_string
-
+  @enter_function
   def get_classif_config_data(self):
+      """
+      Get classification configuration data (both labels names and values)
+      :return: 2 DICTIONARIES: one containing the label information; another
+      containing the data for each labels.
+      """
       label_string = {}
       data_string = {}
 
@@ -1336,17 +1041,18 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           label_string.update(label_temp)
           data_string.update(data_temp)
 
-          print('checkboxe label and data string', label_string,
-                '\n', data_string)
-
-      print('succed adding checkbox', label_string,
-            '\n', data_string)
-
       return label_string, data_string
 
 
   @enter_function
   def build_classification_labels(self, classif_label):
+      """
+      Create a dictionary for both header (label names) and classification
+      values.
+      :param classif_label: string of name of type of labels (e.g. "checkboxes")
+      :return: 2 DICTIONARIES one with names and types of columns; another
+      with data values.
+      """
       header_dict = {}
       value_dict = {}
 
@@ -1355,112 +1061,70 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
           local_header_dict = {}
 
-          print('i', i)
-          print('objectname', objectName)
-          print('label111', label)
-          # maxime = {label: classif_label}
-          # print('maxime ', maxime)
-
-
-          # local_header_dict[f"{label}"] = classif_label
-
+          # Adapt the format of label value saving depending of the type
           if classif_label == "checkboxes":
               local_header_dict[label] = classif_label
               data = "No"
               if self.checkboxWidgets[objectName].isChecked():
                   data = "Yes"
-              print('data', data)
 
           elif classif_label == "comboboxes":
-
               local_header_dict[objectName] = classif_label
-
-
               data = self.comboboxWidgets[objectName].currentText
-              print('data')
 
           elif classif_label == "freetextboxes":
               local_header_dict[label] = classif_label
               data = self.freeTextBoxes[objectName].text.replace(
                   "\n", " // ")
 
-
           header_dict[f"{local_header_dict}"] = classif_label
-
-
-
-
-      # for i, (comboBoxName, options) in enumerate(
-      #         self.config_yaml["comboboxes"].items()):
-      #     label = comboBoxName.replace("_", " ").capitalize()
-      #
-      #     if label_string != "":
-      #         label_string = label_string + ","
-      #         data_string = data_string + ","
-      #
-      #     label_string = label_string + label
-
-
-          # print('string to save', )
-          #
-          # if label_string != "":
-          #     label_string = label_string + ","
-          #     data_string = data_string + ","
-          #
-          # print('label_stirng', label_string)
-          #
-          # label_string = label_string + label
-
-
-
-
           value_dict[f"{local_header_dict}"] = data
-
-          print('value dict local', value_dict)
-
-          # header_dict[label] = "checkboxes"
-
-
-      # header_dict = ",".join(header_dict)
-      print('string header dict', header_dict)
-      # value_dict = ",".join(value_dict.values())
-      print('string value dict', value_dict)
 
       return header_dict, value_dict
 
-
-
-          # data_string = data_string + data
-
-
   @enter_function
   def add_missing_columns_to_df(self, df, columns_dict):
+      """
+      Add columns to a dataframe if it is not in dictionary.
+      :param df: dataframe to check if columns are present
+      :columns_dict: dictionary of all columns needed.
+      :return: dataframe with all required columns.
+      If column is not already existing, all non-existing columns for existing
+      rows are filled with '--' (this helps tracing back if classification
+      configuration has changed).
+      """
       # Add missing columns from the dictionary
       for column in columns_dict:
           if column not in df.columns:
               # df[column] = np.nan
               df[column] = '--'
-
       return df
 
   @enter_function
   def add_mark_for_removed_columns(self, dfcsv, slicer_dict):
       """
+      Add '--' in the actual data for previously existing column that has
+      been removed in the actual configuration.
       :param dfcsv: dataframe from previous csv file
       :param slicer_dict: dictionary of classification labels from slicer ui.
+      :return: dictionary of data with all previously existing columns and
+      actual columns (removed or added).
       """
       initial_columns = dfcsv.columns.tolist()
       for column in initial_columns:
           if column not in slicer_dict:
-              print('column in new config has been removed')
               slicer_dict[column] = '--'
-
       return slicer_dict
-
-
 
   @enter_function
   def convert_string_values_to_list_element(self, dict):
+      """
+      Ensure each value of a dictionary containing columns name as keys and
+      values as column values are formatted to list to make it comptabile
+      with using pandas functions.
+      :param: dict: dictionary to make compatible.
+      :return: dictionary compatible to be converted to dataframe.
+      """
       # Ensure all values are lists
       for key in dict:
           if not isinstance(dict[key], list):
@@ -1469,16 +1133,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
   @enter_function
   def combine_dict(self, dict1, dict2):
-
-      # Replace empty string lists with empty strings in both dictionaries
-      # def replace_empty_string_lists(d):
-      #     return {key: ["" if isinstance(val, list) and len(val) == 1 and val[
-      #         0] == "" else val for val in value]
-      #             for key, value in d.items()}
-      #
-      # dict1 = replace_empty_string_lists(dict1)
-      # dict2 = replace_empty_string_lists(dict2)
-
+      """
+      Combine 2 dictionaries into a dataframe
+      :param dict1 first dictionary to combine
+      :param dict2 second dictionary to combine
+      :return: dataframe with both dictionary content
+      """
       # Convert dictionaries to DataFrames
       df1 = pd.DataFrame(dict1)
       df2 = pd.DataFrame(dict2)
@@ -1486,46 +1146,17 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Concatenate the DataFrames
       result_df = pd.concat([df1, df2], ignore_index=True)
       return result_df
-      # # Combine the dictionaries by appending values
-      # combined_dict = {}
-      #
-      # print('dcit1 in combine, ', len(dict1))
-      # print('dict2 in combine', len(dict2))
-      #
-      # for key in dict1.keys():
-      #     print('key', key)
-      #     values1 = dict1.get(key, [])  # Get values from dict1 or an empty list
-      #     print('value1', values1)
-      #     values2 = dict2.get(key, [])  # Get values from dict2 or an empty list
-      #     print('values2', values2)
-      #     combined_dict[key] = values1 + values2  # Append values
-      # return combined_dict
 
-  # @enter_function
-  # def extract_header_from_df(self, df):
-  #     label_string = {}
-  #     columns_name = list(df.columns.tolist())
-  #     print('columns name', columns_name)
-  #     for col in columns_name:
-  #         local_dict = {}
-  #
-  #         try:
-  #
-  #             col_name = dict(col)
-  #             for element in col_name:
-  #                 name = f"{col}"
-  #                 value = col_name[element]
-  #                 local_dict[name] = value
-  #         except ValueError:
-  #             value = col
-  #
-  #
-  #         label_string[col] = value
   @enter_function
   def extract_header_from_df(self, df):
+      """
+      Extract columns name from dataframe.
+      :param: df: dataframe
+      :return: dictionary of columns names as keys and type of
+      classification label as values.
+      """
       label_string = {}
       columns_name = list(df.columns.tolist())  # Get a list of column names
-      print('Columns name:', columns_name)
 
       for col in columns_name:
           try:
@@ -1539,35 +1170,16 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
               # Handle cases where col is not a valid dictionary
               label_string[col] = col
 
-      # for col in columns_name:
-      #     try:
-      #         # Attempt to evaluate the string as a dictionary
-      #         col_dict = eval(col)
-      #         if isinstance(col_dict, dict):
-      #             dict_name = {}
-      #             dict_value = dict(col)
-      #             dict_name[f"{col}"]: str(dict_value.values())
-      #             print(f'dict name for {col}', dict_name)
-      #         # if isinstance(col_dict, dict):
-      #         #     # Extract key-value pairs from the dictionary
-      #         #     for key, value in col_dict.items():
-      #         #         label_string[key] = value
-      #     except ValueError:
-      #         print('entering ecept', col)
-      #         # If not a valid dictionary, just use the column name
-      #         label_string[col] = col
-
-          # return label_string
-
-      print('label_string extracted', label_string)
-
       return label_string
-
-    # RENDU ICI CONVERTIR ELEMENTS EN STRING POUR ETRE FORMATTES
-  # ajouter savegarder le dateitme dans classification
 
   @enter_function
   def build_current_classif_dictionary(self):
+      """
+      Build dictionary with current demographic and general Slicer annotator
+      information.
+      :return: dictionary where keys are Column name for general information
+      and values are corresponding data from actual configuration.
+      """
       currentClassificationInformationVersion = self.getClassificationInformationVersion()
       print('info current build', currentClassificationInformationVersion)
       info_dict = {}
@@ -1577,12 +1189,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       info_dict['Annotator degree'] = self.annotator_degree
       info_dict['Revision step'] = self.ui.RevisionStep.currentText
       info_dict['Date and time'] = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+
       return info_dict
-
-
-
-
-
 
   @enter_function
   def cast_segmentation_to_uint8(self):
@@ -1867,139 +1475,19 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         with open(self.outputSegmentationInformationFile, 'w') as f:
             f.write(tag_str + "\n")
             f.write(data_str + "\n")
-        
-  # @enter_function
-  # def saveClassificationInformation(self, classification_information_labels_string, classification_information_data_string):
-  #       currentClassificationInformationVersion = self.getClassificationInformationVersion()
-  #
-  #       tag_str = "Volume filename,Classification version,Annotator Name,Annotator degree,Revision step,Date and time"
-  #       tag_str = tag_str + "," + classification_information_labels_string
-  #
-  #       data_str = self.currentCase
-  #       data_str = data_str + "," + currentClassificationInformationVersion
-  #       data_str = data_str + "," + self.annotator_name
-  #       data_str = data_str + "," + self.annotator_degree
-  #       data_str = data_str + "," + self.revision_step[0]
-  #       data_str = data_str + "," + datetime.today().strftime('%Y-%m-%d %H:%M:%S')
-  #       data_str = data_str + "," + classification_information_data_string
-  #
-  #       self.outputClassificationInformationFile = os.path.join(self.currentOutputPath,
-  #                                           '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
-  #       if not os.path.isfile(self.outputClassificationInformationFile):
-  #           with open(self.outputClassificationInformationFile, 'w') as f:
-  #               f.write(tag_str)
-  #               f.write("\n")
-  #               f.write(data_str)
-  #       else:
-  #           with open(self.outputClassificationInformationFile, 'a') as f:
-  #               f.write("\n")
-  #               f.write(data_str)
 
-  # @enter_function
-  # def saveClassificationInformation(self,
-  #                                   classification_information_labels_string,
-  #                                   classification_information_data_string):
-  #     currentClassificationInformationVersion = self.getClassificationInformationVersion()
-  #
-  #     tag_str = "Volume filename,Classification version,Annotator Name,Annotator degree,Revision step,Date and time"
-  #     tag_str = tag_str + "," + classification_information_labels_string
-  #
-  #     data_str = self.currentCase
-  #     data_str = data_str + "," + currentClassificationInformationVersion
-  #     data_str = data_str + "," + self.annotator_name
-  #     data_str = data_str + "," + self.annotator_degree
-  #     data_str = data_str + "," + self.revision_step[0]
-  #     data_str = data_str + "," + datetime.today().strftime('%Y-%m-%d %H:%M:%S')
-  #     data_str = data_str + "," + classification_information_data_string
-  #
-  #     self.outputClassificationInformationFile = os.path.join(
-  #         self.currentOutputPath,
-  #         '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
-  #     if not os.path.isfile(self.outputClassificationInformationFile):
-  #         with open(self.outputClassificationInformationFile, 'w') as f:
-  #             f.write(tag_str)
-  #             f.write("\n")
-  #             f.write(data_str)
-  #     else:
-  #         with open(self.outputClassificationInformationFile, 'a') as f:
-  #             f.write("\n")
-  #             f.write(data_str)
   @enter_function
   def saveClassificationInformation(self, classification_df):
-      # currentClassificationInformationVersion = self.getClassificationInformationVersion()
-
-      # tag_str = "Volume filename,Classification version,Annotator Name,Annotator degree,Revision step,Date and time"
-      #
-      #
-      #
-      # classification_information_labels_string = ",".join(
-      #     classification_information_labels_string.keys())
-      #
-      # tag_str = tag_str + "," + classification_information_labels_string
-      #
-      # data_str = self.build_current_classif_dictionary()
-      # data_str = ",".join(data_str.values())
-      # print('data_str = ', data_str)
-
-      # data_str = data_str + "," + classification_information_data_string #
-      # need to modify classificaiton information dat string
-
+      """
+      Save updated classification information to a csv file.
+      :param: dataframe containing all updated classification data.
+      """
       self.outputClassificationInformationFile = os.path.join(
           self.currentOutputPath,
           '{}_ClassificationInformation.csv'.format(self.currentVolumeFilename))
 
       classification_df.to_csv(self.outputClassificationInformationFile,
                                index=False)
-
-      # if not os.path.isfile(self.outputClassificationInformationFile):
-      #     classification_df.to_csv(self.outputClassificationInformationFile,
-      #                              index=False)
-      #
-      #     # with open(self.outputClassificationInformationFile, 'w') as f:
-      #
-      #
-      #
-      #         # f.write(tag_str)
-      #         # f.write("\n")
-      #         #
-      #         # classification_information_data_string = ",".join(
-      #         #     classification_information_data_string.values())
-      #         #
-      #         # print('classificiton information data frstin')
-      #         #
-      #         # data_str = data_str + "," + classification_information_data_string
-      #         # f.write(data_str)
-      # else:
-      #     print('in else before writing')
-      #
-      #     classification_df.to_csv(self.outputClassificationInformationFile,
-      #                              index=False)
-
-          #
-          # classification_information_data_string = ",".join(
-          #     classification_information_data_string.values())
-          #
-          # with open(self.outputClassificationInformationFile, 'r') as f:
-          #     content = pd.read_csv(f)
-          #
-          #
-          # print('content', content)
-          # Debug.df_file(self, content, self.outputFolder)
-
-
-
-
-
-
-
-          # with open(self.outputClassificationInformationFile, 'a') as f:
-          #     f.write("\n")
-          #     f.write(data_str)
-
-
-  def get_classification_df(self, columns):
-      df = pd.DataFrame(columns=columns)
-      return df
 
   def getClassificationInformationVersion(self):
       version = "v"
@@ -2091,24 +1579,20 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Save the associated volume_folder_path with the output_folder selected.
       UserPath.write_in_filepath(self, self.outputFolder, self.CurrentFolder)
 
-
-      print('self config labels checkbo', INITIAL_CONFIG_FILE)
+      # Update classification labels (part 1 of 2)
       initial_config_content = ConfigPath.get_initial_config_after_modif()
-      print('\n\n actual config file', initial_config_content)
-
       temp_dict = ConfigPath.extract_config_classification(
           initial_config_content)
 
       self.manage_workflow()
 
+      # Update classification labels (part 2 of 2)
+      # To do after manage workflow because manage workflow looks for the
+      # optimal configuration file to use.
       self.config_yaml = ConfigPath.compare_and_merge_classification(
           self.config_yaml, temp_dict)
 
-      print('self config yaml afetr manag workfloe and updated', self.config_yaml)
-
       ConfigPath.write_config_file()
-
-      print(' self config yaml after write config file', self.config_yaml)
 
       self.set_ui_enabled_options()
 
@@ -2213,20 +1697,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.annotator_name = self.ui.Annotator_name.text
       self.annotator_degree = self.ui.AnnotatorDegree.currentText
 
-      # classification_information_labels_string, classification_information_data_string \
-      #     = self.getClassificationInformation()
-
       classification_df = self.getClassificationInformation()
       
       # Create folders if don't exist
       self.createFolders()
 
       if self.annotator_name is not None:
-
-          print(' save class no none classif ino label string', classification_df)
-          print('\n\nclassificaitno information label data string',
-                classification_df)
-
           self.saveClassificationInformation(classification_df)
           msg_box = qt.QMessageBox()
           msg_box.setWindowTitle("Success")

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -217,14 +217,16 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.UB_HU.setValue(self.UB_HU)
         self.ui.LB_HU.setValue(self.LB_HU)
 
-        # clear classification widgets
-        for i in reversed(range(self.ui.ClassificationGridLayout.count())): 
-            if self.ui.ClassificationGridLayout.itemAt(i).widget() is not None:
-                self.ui.ClassificationGridLayout.itemAt(i).widget().setParent(None)
+        self.set_classification_config_ui()
 
-        comboboxesStartRow = self.setupCheckboxes(3)
-        freetextStartRow = self.setupComboboxes(comboboxesStartRow)
-        self.setupFreeText(freetextStartRow)
+        # # clear classification widgets
+        # for i in reversed(range(self.ui.ClassificationGridLayout.count())):
+        #     if self.ui.ClassificationGridLayout.itemAt(i).widget() is not None:
+        #         self.ui.ClassificationGridLayout.itemAt(i).widget().setParent(None)
+        #
+        # comboboxesStartRow = self.setupCheckboxes(3)
+        # freetextStartRow = self.setupComboboxes(comboboxesStartRow)
+        # self.setupFreeText(freetextStartRow)
         
         # Initialize timers
         self.timers = []
@@ -279,6 +281,19 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         for label in self.config_yaml["labels"]:
             self.ui.dropDownButton_label_select.addItem(label["name"])
   
+  @enter_function
+  def set_classification_config_ui(self):
+      # clear classification widgets
+      for i in reversed(range(self.ui.ClassificationGridLayout.count())):
+          if self.ui.ClassificationGridLayout.itemAt(i).widget() is not None:
+              self.ui.ClassificationGridLayout.itemAt(i).widget().setParent(
+                  None)
+
+      comboboxesStartRow = self.setupCheckboxes(3)
+      freetextStartRow = self.setupComboboxes(comboboxesStartRow)
+      self.setupFreeText(freetextStartRow)
+
+
   def set_master_volume_intensity_mask_according_to_modality(self):
       if ConfigPath.MODALITY == 'CT':
             self.segmentEditorNode.SetMasterVolumeIntensityMask(True)
@@ -434,7 +449,13 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       if self.outputFolder != None:
           UserPath.write_in_filepath(self, self.outputFolder,
                                      self.CurrentFolder)
-          self.manage_workflow()
+          print('fomr contineu exitinsg config')
+          self.manage_workflow_and_classification()
+          print('amange worked')
+          # self.set_classification_config_ui()
+          print('classif souhld be ok')
+
+          # self.manage_workflow()
 
   @enter_function
   def reset_ui(self):
@@ -1579,6 +1600,26 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       # Save the associated volume_folder_path with the output_folder selected.
       UserPath.write_in_filepath(self, self.outputFolder, self.CurrentFolder)
 
+      self.manage_workflow_and_classification()
+      # # Update classification labels (part 1 of 2)
+      # initial_config_content = ConfigPath.get_initial_config_after_modif()
+      # temp_dict = ConfigPath.extract_config_classification(
+      #     initial_config_content)
+      #
+      # self.manage_workflow()
+      #
+      # # Update classification labels (part 2 of 2)
+      # # To do after manage workflow because manage workflow looks for the
+      # # optimal configuration file to use.
+      # self.config_yaml = ConfigPath.compare_and_merge_classification(
+      #     self.config_yaml, temp_dict)
+
+      ConfigPath.write_config_file()
+
+      self.set_ui_enabled_options()
+
+  @enter_function
+  def manage_workflow_and_classification(self):
       # Update classification labels (part 1 of 2)
       initial_config_content = ConfigPath.get_initial_config_after_modif()
       temp_dict = ConfigPath.extract_config_classification(
@@ -1592,9 +1633,8 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.config_yaml = ConfigPath.compare_and_merge_classification(
           self.config_yaml, temp_dict)
 
-      ConfigPath.write_config_file()
-
-      self.set_ui_enabled_options()
+      # Load classification parameters in the ui
+      self.set_classification_config_ui()
 
   @enter_function
   def set_ui_enabled_options(self):

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -219,14 +219,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.set_classification_config_ui()
 
-        # # clear classification widgets
-        # for i in reversed(range(self.ui.ClassificationGridLayout.count())):
-        #     if self.ui.ClassificationGridLayout.itemAt(i).widget() is not None:
-        #         self.ui.ClassificationGridLayout.itemAt(i).widget().setParent(None)
-        #
-        # comboboxesStartRow = self.setupCheckboxes(3)
-        # freetextStartRow = self.setupComboboxes(comboboxesStartRow)
-        # self.setupFreeText(freetextStartRow)
         
         # Initialize timers
         self.timers = []
@@ -292,7 +284,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       comboboxesStartRow = self.setupCheckboxes(3)
       freetextStartRow = self.setupComboboxes(comboboxesStartRow)
       self.setupFreeText(freetextStartRow)
-
 
   def set_master_volume_intensity_mask_according_to_modality(self):
       if ConfigPath.MODALITY == 'CT':
@@ -449,13 +440,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       if self.outputFolder != None:
           UserPath.write_in_filepath(self, self.outputFolder,
                                      self.CurrentFolder)
-          print('fomr contineu exitinsg config')
           self.manage_workflow_and_classification()
-          print('amange worked')
-          # self.set_classification_config_ui()
-          print('classif souhld be ok')
-
-          # self.manage_workflow()
 
   @enter_function
   def reset_ui(self):
@@ -969,7 +954,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 self.freeTextBoxes[freeTextBoxObjectName].setText("")
         except:
             pass
-
 
   @enter_function
   def getClassificationInformation(self):
@@ -1601,18 +1585,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       UserPath.write_in_filepath(self, self.outputFolder, self.CurrentFolder)
 
       self.manage_workflow_and_classification()
-      # # Update classification labels (part 1 of 2)
-      # initial_config_content = ConfigPath.get_initial_config_after_modif()
-      # temp_dict = ConfigPath.extract_config_classification(
-      #     initial_config_content)
-      #
-      # self.manage_workflow()
-      #
-      # # Update classification labels (part 2 of 2)
-      # # To do after manage workflow because manage workflow looks for the
-      # # optimal configuration file to use.
-      # self.config_yaml = ConfigPath.compare_and_merge_classification(
-      #     self.config_yaml, temp_dict)
 
       ConfigPath.write_config_file()
 
@@ -1749,7 +1721,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           msg_box.setIcon(qt.QMessageBox.Information)
           msg_box.setText("Classification saved successfully!")
           msg_box.exec()
-
 
       else:
           msgboxtime = qt.QMessageBox()

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -21,7 +21,9 @@ KEYBOARD_SHORTCUTS:
   callback: onPushButton_Interpolate
   shortcut: i
 checkboxes:
+  Anoxic_injury_checkbox: Anoxic injury
   Brain_edema_checkbox: Brain edema
+  Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
   EDH_checkbox: EDH
   EVD_checkbox: EVD
@@ -38,8 +40,13 @@ checkboxes:
   Pressure_monitor_checkbox: Pressure monitor
   SAH_checkbox: SAH
   SDH_checkbox: SDH
-  za1: Za1
+  Tonsillar_herniation_checkbox: Tonsillar herniation
 comboboxes:
+  atrophy:
+    atrophy_mild: Mild
+    atrophy_moderate: Moderate
+    atrophy_none: None
+    atrophy_severe: Severe
   test_dd:
     '1': '1'
   ventricular_size:
@@ -59,8 +66,6 @@ default_volume_directory: ''
 enable_debug: true
 freetextboxes:
   cheese: Cheese
-  kiki: Kiki
-  maxime: Maxime
   number_of_focal_points: Number of focal points
   other_comments: Comments
 impose_bids_format: false

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -41,8 +41,8 @@ checkboxes:
   SDH_checkbox: SDH
   Tonsillar_herniation_checkbox: Tonsillar herniation
   toto: Toto
-  z1: Z1
-  z2: Z2
+  za1: Za1
+  zz: Zz
 comboboxes:
   test_dd:
     '1': '1'

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -21,7 +21,6 @@ KEYBOARD_SHORTCUTS:
   callback: onPushButton_Interpolate
   shortcut: i
 checkboxes:
-  Anoxic_injury_checkbox: Anoxic injury
   Brain_edema_checkbox: Brain edema
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
@@ -41,12 +40,8 @@ checkboxes:
   SAH_checkbox: SAH
   SDH_checkbox: SDH
   Tonsillar_herniation_checkbox: Tonsillar herniation
+  toto: Toto
 comboboxes:
-  atrophy:
-    atrophy_mild: Mild
-    atrophy_moderate: Moderate
-    atrophy_none: None
-    atrophy_severe: Severe
   test_dd:
     '1': '1'
   ventricular_size:
@@ -66,6 +61,7 @@ default_volume_directory: ''
 enable_debug: true
 freetextboxes:
   cheese: Cheese
+  maxime: Maxime
   number_of_focal_points: Number of focal points
   other_comments: Comments
 impose_bids_format: false

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -21,8 +21,6 @@ KEYBOARD_SHORTCUTS:
   callback: onPushButton_Interpolate
   shortcut: i
 checkboxes:
-  Anoxic_injury_checkbox: Anoxic injury
-  Brain_edema_checkbox: Brain edema
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
   EDH_checkbox: EDH
@@ -40,15 +38,13 @@ checkboxes:
   Pressure_monitor_checkbox: Pressure monitor
   SAH_checkbox: SAH
   SDH_checkbox: SDH
-  Tonsillar_herniation_checkbox: Tonsillar herniation
+  maxime: Maxime
 comboboxes:
   atrophy:
     atrophy_mild: Mild
     atrophy_moderate: Moderate
     atrophy_none: None
     atrophy_severe: Severe
-  test_dd:
-    '1': '1'
   ventricular_size:
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate
@@ -65,6 +61,7 @@ default_segmentation_directory: ''
 default_volume_directory: ''
 enable_debug: true
 freetextboxes:
+  anika: Anika
   cheese: Cheese
   number_of_focal_points: Number of focal points
   other_comments: Comments

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -22,7 +22,6 @@ KEYBOARD_SHORTCUTS:
   shortcut: i
 checkboxes:
   Brain_edema_checkbox: Brain edema
-  Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
   EDH_checkbox: EDH
   EVD_checkbox: EVD
@@ -37,10 +36,13 @@ checkboxes:
   Multiple_lesions_checkbox: Multiple lesions
   Normal_checkbox: Normal
   Pressure_monitor_checkbox: Pressure monitor
+  QWETY: Qwety
   SAH_checkbox: SAH
   SDH_checkbox: SDH
   Tonsillar_herniation_checkbox: Tonsillar herniation
   toto: Toto
+  z1: Z1
+  z2: Z2
 comboboxes:
   test_dd:
     '1': '1'

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -21,6 +21,8 @@ KEYBOARD_SHORTCUTS:
   callback: onPushButton_Interpolate
   shortcut: i
 checkboxes:
+  Anoxic_injury_checkbox: Anoxic injury
+  Brain_edema_checkbox: Brain edema
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
   EDH_checkbox: EDH
@@ -38,13 +40,15 @@ checkboxes:
   Pressure_monitor_checkbox: Pressure monitor
   SAH_checkbox: SAH
   SDH_checkbox: SDH
-  maxime: Maxime
+  Tonsillar_herniation_checkbox: Tonsillar herniation
 comboboxes:
   atrophy:
     atrophy_mild: Mild
     atrophy_moderate: Moderate
     atrophy_none: None
     atrophy_severe: Severe
+  test_dd:
+    '1': '1'
   ventricular_size:
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate
@@ -61,7 +65,6 @@ default_segmentation_directory: ''
 default_volume_directory: ''
 enable_debug: true
 freetextboxes:
-  anika: Anika
   cheese: Cheese
   number_of_focal_points: Number of focal points
   other_comments: Comments

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -36,13 +36,9 @@ checkboxes:
   Multiple_lesions_checkbox: Multiple lesions
   Normal_checkbox: Normal
   Pressure_monitor_checkbox: Pressure monitor
-  QWETY: Qwety
   SAH_checkbox: SAH
   SDH_checkbox: SDH
-  Tonsillar_herniation_checkbox: Tonsillar herniation
-  toto: Toto
   za1: Za1
-  zz: Zz
 comboboxes:
   test_dd:
     '1': '1'
@@ -63,6 +59,7 @@ default_volume_directory: ''
 enable_debug: true
 freetextboxes:
   cheese: Cheese
+  kiki: Kiki
   maxime: Maxime
   number_of_focal_points: Number of focal points
   other_comments: Comments

--- a/SlicerCART/src/scripts/LoadClassificationWindow.py
+++ b/SlicerCART/src/scripts/LoadClassificationWindow.py
@@ -23,8 +23,6 @@ class LoadClassificationWindow(qt.QWidget):
 
       layout.addLayout(buttonLayout)
 
-      print('classificationInformation_df shape 0: ', classificationInformation_df.shape[0])
-
       if classificationInformation_df.shape[0] > 0:
           available_versions = classificationInformation_df['Classification version'].to_list()
           for v in available_versions:
@@ -74,11 +72,8 @@ class LoadClassificationWindow(qt.QWidget):
 
    @enter_function
    def pushLoad(self):
-       print('self version dorpdown currenttext', self.versionDropdown.currentText)
-
        selected_version = self.versionDropdown.currentText
        selected_version_df = self.classificationInformation_df[self.classificationInformation_df['Classification version']==selected_version].reset_index(drop = True)
-       print('selected version df', selected_version_df)
 
        for i, (objectName, label) in enumerate(self.segmenter.classification_config_yaml["checkboxes"].items()):
            if selected_version_df.at[0, label] == 'Yes':

--- a/SlicerCART/src/scripts/LoadClassificationWindow.py
+++ b/SlicerCART/src/scripts/LoadClassificationWindow.py
@@ -1,5 +1,6 @@
 from utils import *
 class LoadClassificationWindow(qt.QWidget):
+   @enter_function
    def __init__(self, segmenter, classificationInformation_df, parent = None):
       super(LoadClassificationWindow, self).__init__(parent)
 
@@ -21,6 +22,8 @@ class LoadClassificationWindow(qt.QWidget):
       buttonLayout.addWidget(self.versionDropdown)
 
       layout.addLayout(buttonLayout)
+
+      print('classificationInformation_df shape 0: ', classificationInformation_df.shape[0])
 
       if classificationInformation_df.shape[0] > 0:
           available_versions = classificationInformation_df['Classification version'].to_list()
@@ -69,9 +72,13 @@ class LoadClassificationWindow(qt.QWidget):
       self.setWindowTitle("Load Classification")
       self.resize(800, 400)
 
+   @enter_function
    def pushLoad(self):
+       print('self version dorpdown currenttext', self.versionDropdown.currentText)
+
        selected_version = self.versionDropdown.currentText
        selected_version_df = self.classificationInformation_df[self.classificationInformation_df['Classification version']==selected_version].reset_index(drop = True)
+       print('selected version df', selected_version_df)
 
        for i, (objectName, label) in enumerate(self.segmenter.classification_config_yaml["checkboxes"].items()):
            if selected_version_df.at[0, label] == 'Yes':

--- a/SlicerCART/src/utils/ConfigPath.py
+++ b/SlicerCART/src/utils/ConfigPath.py
@@ -156,6 +156,7 @@ class ConfigPath():
             with open(CONFIG_FILE_PATH, 'w') as file:
                 yaml.safe_dump(self.config_yaml, file)
         else:
+            print('in else write config file')
             output_path = ConfigPath.read_temp_file(name=OUTPUT_CONFIG_PATH)
             with open(output_path, 'w') as file:
                 yaml.safe_dump(self.config_yaml, file)
@@ -243,6 +244,58 @@ class ConfigPath():
         Set output folder to ConfigPath class.
         """
         self.outputFolder = outputFolder
+
+    @enter_function
+    def get_initial_config_after_modif(self):
+        # Read at startup the initial config file
+        with open(CONFIG_FILE_PATH, 'r') as file:
+            content = yaml.safe_load(file)
+        return content
+
+    @enter_function
+    def extract_config_classification(self, content):
+        """
+        content == content of a config file
+        """
+        classif_dict = {}
+        for element in CLASSIFICATION_BOXES_LIST:
+            classif_dict[element] = content[element]
+
+        print('classif dict', classif_dict)
+        Debug.print_dictionary(self, classif_dict)
+        return classif_dict
+
+    @enter_function
+    def compare_and_merge_classification(self, final_config_file, temp_dict):
+        final_dict = {}
+        initial_config_file_dict = ConfigPath.extract_config_classification(final_config_file)
+
+        print('final config file before\n\n\n', final_config_file)
+
+        for key in list(
+                initial_config_file_dict.keys()):  # Use list() to avoid RuntimeError
+            if key not in temp_dict:
+                del initial_config_file_dict[key]
+
+        # Add or update keys from temp_dict to initial_config_file_dict
+        for key, value in temp_dict.items():
+            initial_config_file_dict[key] = value
+
+        print('\n\n\ninitial config file dic FINAL', initial_config_file_dict)
+
+        for element in initial_config_file_dict:
+            final_config_file[element] = initial_config_file_dict[element]
+
+        print('final config file dic FINAL after', final_config_file)
+
+        return final_config_file
+
+
+
+
+
+
+
 
 
 # Creating an instance of ConfigPath. This ensures that all the same

--- a/SlicerCART/src/utils/ConfigPath.py
+++ b/SlicerCART/src/utils/ConfigPath.py
@@ -156,7 +156,6 @@ class ConfigPath():
             with open(CONFIG_FILE_PATH, 'w') as file:
                 yaml.safe_dump(self.config_yaml, file)
         else:
-            print('in else write config file')
             output_path = ConfigPath.read_temp_file(name=OUTPUT_CONFIG_PATH)
             with open(output_path, 'w') as file:
                 yaml.safe_dump(self.config_yaml, file)
@@ -247,6 +246,11 @@ class ConfigPath():
 
     @enter_function
     def get_initial_config_after_modif(self):
+        """
+        Read the initial configuration file. To use after Slicer
+        Configuration Set Up Window has been modified.
+        :return: content of the initial configuration file (dictionary)
+        """
         # Read at startup the initial config file
         with open(CONFIG_FILE_PATH, 'r') as file:
             content = yaml.safe_load(file)
@@ -255,22 +259,29 @@ class ConfigPath():
     @enter_function
     def extract_config_classification(self, content):
         """
-        content == content of a config file
+        Get only the classification configuration from the content of a
+        config file.
+        :param content: content of a config file
+        :return: classification labels as a dictionary
         """
         classif_dict = {}
         for element in CLASSIFICATION_BOXES_LIST:
             classif_dict[element] = content[element]
-
-        print('classif dict', classif_dict)
-        Debug.print_dictionary(self, classif_dict)
         return classif_dict
 
     @enter_function
     def compare_and_merge_classification(self, final_config_file, temp_dict):
-        final_dict = {}
-        initial_config_file_dict = ConfigPath.extract_config_classification(final_config_file)
+        """
+        Compare possibly modified classification labels with final config
+        file (e.g. in the output folder or the initial config file if output
+        folder has not yet been selected).
+        :param: final_config_file: content of final config file (dictionary)
+        :param: temp_dict: dictionary containing classification labels
+        :return: final config file content (all config parameters)
+        """
 
-        print('final config file before\n\n\n', final_config_file)
+        initial_config_file_dict = (
+            ConfigPath.extract_config_classification(final_config_file))
 
         for key in list(
                 initial_config_file_dict.keys()):  # Use list() to avoid RuntimeError
@@ -281,21 +292,10 @@ class ConfigPath():
         for key, value in temp_dict.items():
             initial_config_file_dict[key] = value
 
-        print('\n\n\ninitial config file dic FINAL', initial_config_file_dict)
-
         for element in initial_config_file_dict:
             final_config_file[element] = initial_config_file_dict[element]
 
-        print('final config file dic FINAL after', final_config_file)
-
         return final_config_file
-
-
-
-
-
-
-
 
 
 # Creating an instance of ConfigPath. This ensures that all the same

--- a/SlicerCART/src/utils/constants.py
+++ b/SlicerCART/src/utils/constants.py
@@ -27,3 +27,6 @@ print('CONFIG_FILE_PATH from file constants.py: ', CONFIG_FILE_PATH)
 with open(CONFIG_FILE_PATH, 'r') as file:
     content = yaml.safe_load(file)
 INITIAL_CONFIG_FILE = content
+
+CLASSIFICATION_BOXES_LIST = ["checkboxes", "comboboxes", "freetextboxes"]
+

--- a/SlicerCART/src/utils/constants.py
+++ b/SlicerCART/src/utils/constants.py
@@ -28,5 +28,5 @@ with open(CONFIG_FILE_PATH, 'r') as file:
     content = yaml.safe_load(file)
 INITIAL_CONFIG_FILE = content
 
+# Configuration sections names for classification labels
 CLASSIFICATION_BOXES_LIST = ["checkboxes", "comboboxes", "freetextboxes"]
-

--- a/SlicerCART/src/utils/debugging_helpers.py
+++ b/SlicerCART/src/utils/debugging_helpers.py
@@ -1,6 +1,8 @@
 import functools
 import inspect
 import yaml
+import os
+import pandas as pd
 
 # Import initial configuration filepath associated with SlicerCART module.
 from utils.constants import CONFIG_FILE_PATH
@@ -56,6 +58,11 @@ class Debug:
         """
         if ENABLE_DEBUG:
             print(statement)
+
+    def df_file(self, df, folderpath):
+        filename = os.path.join(folderpath, 'debug_df.csv')
+        df.to_csv(filename, index=False)
+
 
 def enter_function(func):
     """

--- a/SlicerCART/src/utils/debugging_helpers.py
+++ b/SlicerCART/src/utils/debugging_helpers.py
@@ -63,7 +63,6 @@ class Debug:
         filename = os.path.join(folderpath, 'debug_df.csv')
         df.to_csv(filename, index=False)
 
-
 def enter_function(func):
     """
     Decorator that enables to print the function name in the python console


### PR DESCRIPTION
This PR:

- Allows to save different versions of classification labels to a single csv file listing the different versions.
- If previously existing labels have been removed in the current classificatino labels, the saving will work and a string -- will be added in the column from the latest version that has been removed
- If columns have been added (new classification labels) from previous classification labels configuration, a string -- will be added in the rows of the previous versions where the columns did not exist.
- Names of the columns have been reformatted to a string dictionary {'column name': type_of_classification_label} -- this will enable to reconstruct classification labels ui when loading classification will be done (this will be donex in further PR).

How to test?
1. Open Slicer
2. Start from new configuration or pre-existing configuration or just select volume folders directly (edit the number of classificaiton labels that you want; add and/or remove)
3. Select volumes and output folders.
4. Do classificaiton task
5. Click on save classification