### PR TITLE
Fixes 133 Select next case when saving classification labels

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -1716,11 +1716,18 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       if self.annotator_name is not None:
           self.saveClassificationInformation(classification_df)
-          msg_box = qt.QMessageBox()
-          msg_box.setWindowTitle("Success")
-          msg_box.setIcon(qt.QMessageBox.Information)
-          msg_box.setText("Classification saved successfully!")
-          msg_box.exec()
+          # Those lines can be re-activated if wanted to display a success
+          # message when saved.
+          # msg_box = qt.QMessageBox()
+          # msg_box.setWindowTitle("Success")
+          # msg_box.setIcon(qt.QMessageBox.Information)
+          # msg_box.setText("Classification saved successfully!")
+          # msg_box.exec()
+
+          # Go automatically to the next case in the UI list when
+          # classification has been saved (if it<s the last case, it stays on
+          # it)
+          self.onNextButton()
 
       else:
           msgboxtime = qt.QMessageBox()

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -21,9 +21,11 @@ KEYBOARD_SHORTCUTS:
   callback: onPushButton_Interpolate
   shortcut: i
 checkboxes:
+  Anoxic_injury_checkbox: Anoxic injury
+  Brain_edema_checkbox: Brain edema
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
-  EDH: Edh
+  EDH_checkbox: EDH
   EVD_checkbox: EVD
   ICH_checkbox: ICH
   IVH_checkbox: IVH
@@ -39,9 +41,14 @@ checkboxes:
   SAH_checkbox: SAH
   SDH_checkbox: SDH
   Tonsillar_herniation_checkbox: Tonsillar herniation
-  roto: Roto
-  zz: Zz
 comboboxes:
+  atrophy:
+    atrophy_mild: Mild
+    atrophy_moderate: Moderate
+    atrophy_none: None
+    atrophy_severe: Severe
+  test_dd:
+    '1': '1'
   ventricular_size:
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate
@@ -59,8 +66,8 @@ default_volume_directory: ''
 enable_debug: true
 freetextboxes:
   cheese: Cheese
-  maxime: Maxime
   number_of_focal_points: Number of focal points
+  other_comments: Comments
 impose_bids_format: false
 input_filetype: '*.nii.gz'
 interpolate_value: 0

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -21,11 +21,9 @@ KEYBOARD_SHORTCUTS:
   callback: onPushButton_Interpolate
   shortcut: i
 checkboxes:
-  Anoxic_injury_checkbox: Anoxic injury
-  Brain_edema_checkbox: Brain edema
   Craniectomy_checkbox: Craniectomy
   Craniotomy_checkbox: Craniotomy
-  EDH_checkbox: EDH
+  EDH: Edh
   EVD_checkbox: EVD
   ICH_checkbox: ICH
   IVH_checkbox: IVH
@@ -41,14 +39,9 @@ checkboxes:
   SAH_checkbox: SAH
   SDH_checkbox: SDH
   Tonsillar_herniation_checkbox: Tonsillar herniation
+  roto: Roto
+  zz: Zz
 comboboxes:
-  atrophy:
-    atrophy_mild: Mild
-    atrophy_moderate: Moderate
-    atrophy_none: None
-    atrophy_severe: Severe
-  test_dd:
-    '1': '1'
   ventricular_size:
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate
@@ -66,8 +59,8 @@ default_volume_directory: ''
 enable_debug: true
 freetextboxes:
   cheese: Cheese
+  maxime: Maxime
   number_of_focal_points: Number of focal points
-  other_comments: Comments
 impose_bids_format: false
 input_filetype: '*.nii.gz'
 interpolate_value: 0


### PR DESCRIPTION
This PR:
- Selects the next case in the UI case list when classification labels has been saved.

How to test?
1. Open Slicer, select volumes and output folder (or continue from existing configuration)
2. Perform classification tasks
3. Click on save classification button
Expected  result: classifiation csv file has been being save and the displayed case is now the next case in the UI case list.

N.B. If the last case classification labels  have been saved, then it remains on the last case, but load it as a new case.