### PR TITLE
fixes 136 Configuration of Classification Drop Down labels does not work

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -275,6 +275,15 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   
   @enter_function
   def set_classification_config_ui(self):
+
+      # (Optional)) get the latest configuration if already exist in output
+      # folder so if configuration has been changed from new configuration
+      # but it already exists in the output folder, the classification labels
+      # would be taken from the output folder. For now, it has been commented
+      # since this would prevent to modify the classification and use it in
+      # an already selected output folder. Uncomment to do above.
+      # self.config_yaml = ConfigPath.open_project_config_file()
+
       # clear classification widgets
       for i in reversed(range(self.ui.ClassificationGridLayout.count())):
           if self.ui.ClassificationGridLayout.itemAt(i).widget() is not None:

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -47,6 +47,10 @@ comboboxes:
     atrophy_moderate: Moderate
     atrophy_none: None
     atrophy_severe: Severe
+  ert:
+    Option_3: Option 3
+    bb: bb
+    dra: dra
   test_dd:
     '1': '1'
   ventricular_size:

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -47,12 +47,14 @@ comboboxes:
     atrophy_moderate: Moderate
     atrophy_none: None
     atrophy_severe: Severe
-  ert:
-    Option_3: Option 3
-    bb: bb
-    dra: dra
   test_dd:
     '1': '1'
+  tre:
+    '3': '3'
+    G: G
+    Option_1: Option 1
+    Option_3: Option 3
+    Zz_z: Zz z
   ventricular_size:
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -47,12 +47,8 @@ comboboxes:
     atrophy_moderate: Moderate
     atrophy_none: None
     atrophy_severe: Severe
-  non:
-    '324': '324'
-    Option_1: Option 1
-    Option_3: Option 3
-    o: o
-    sdf: sdf
+  test_dd:
+    '1': '1'
   ventricular_size:
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate
@@ -70,7 +66,6 @@ default_volume_directory: ''
 enable_debug: true
 freetextboxes:
   cheese: Cheese
-  hhhh: Hhhh
   number_of_focal_points: Number of focal points
   other_comments: Comments
 impose_bids_format: false

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -47,14 +47,12 @@ comboboxes:
     atrophy_moderate: Moderate
     atrophy_none: None
     atrophy_severe: Severe
-  test_dd:
-    '1': '1'
-  tre:
-    '3': '3'
-    G: G
+  non:
+    '324': '324'
     Option_1: Option 1
     Option_3: Option 3
-    Zz_z: Zz z
+    o: o
+    sdf: sdf
   ventricular_size:
     ventricular_size_mild: Mild
     ventricular_size_moderate: Moderate
@@ -72,6 +70,7 @@ default_volume_directory: ''
 enable_debug: true
 freetextboxes:
   cheese: Cheese
+  hhhh: Hhhh
   number_of_focal_points: Number of focal points
   other_comments: Comments
 impose_bids_format: false

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -1710,27 +1710,7 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
 
         layout.addLayout(name_hbox)
 
-        # if self.item_added == 'combobox':
-        #
-        #     print('entering item added combobox init')
-        #
-        #     options_hbox = qt.QHBoxLayout()
-        #     options_label = qt.QLabel('Options : ')
-        #     options_label.setStyleSheet("font-weight: bold")
-        #     options_hbox.addWidget(options_label)
-        #
-        #     self.options_combobox = qt.QComboBox()
-        #     self.options_combobox.setEditable(True)
-        #
-        #     options_hbox.addWidget(self.options_combobox)
-        #
-        #     layout.addLayout(options_hbox)
-
         self.edit_combobox(layout)
-
-
-
-
 
         self.save_button = qt.QPushButton('Save')
         self.save_button.clicked.connect(self.push_save)
@@ -1865,9 +1845,6 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
         current_label_name = self.name_line_edit.text
         object_name = current_label_name.replace(' ', '_')
 
-        print('current label name', current_label_name)
-        print('object name push save', object_name)
-
         if self.item_added == 'checkbox':
             label_found = False
             for i, (_, label) in enumerate(
@@ -1880,9 +1857,7 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                 self.config_yaml['checkboxes'].update(
                     {object_name: current_label_name.capitalize()})
         elif self.item_added == 'combobox':
-            print('in item added == comboxe')
             if self.options_combobox.count == 0:
-                print('in if combo box ==0')
                 msg = qt.QMessageBox()
                 msg.setWindowTitle('ERROR : No Drop Down Options Defined')
                 msg.setText(
@@ -1893,38 +1868,22 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                     self.push_error_no_dropdown_option_defined)
                 msg.exec()
             else:
-                print('combo box should have been added')
                 options_dict = {}
                 combobox_option_items = [self.options_combobox.itemText(i) for i
                                          in range(self.options_combobox.count)]
-
-                print('combo box options items ', combobox_option_items)
-
                 for option in combobox_option_items:
                     options_dict.update({option.replace(' ', '_'): option})
 
                 item_found = False
                 for i, (combobox_name, _) in enumerate(
                         self.config_yaml['comboboxes'].items()):
-                    print('item found true')
-                    print('combobox name', combobox_name)
-                    print('obejct-name', object_name)
                     if combobox_name == object_name:
                         item_found = True
 
                 if item_found == False:
                     # append
-                    print('item false')
-                    print('object name', object_name)
-                    print('option dict', options_dict)
-
-
                     self.config_yaml['comboboxes'].update(
                         {object_name: options_dict})
-
-                print('before save', self.config_yaml['comboboxes'])
-
-
         elif self.item_added == 'freetextbox':
             label_found = False
             for i, (_, label) in enumerate(
@@ -1946,7 +1905,4 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
         self.push_cancel()
 
     def push_cancel(self):
-        configureClassificationWindow = ConfigureClassificationWindow(
-            self.segmenter, self.edit_conf, self.config_yaml)
-        configureClassificationWindow.show()
         self.close()

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -1747,39 +1747,51 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
     @enter_function
     def edit_combobox(self, layout):
         if self.item_added == 'combobox':
-            print('Entering item added combobox init')
 
+            # MB: Create a QHBox layout for the combo box information,
+            # but do not show it yet in the pop-up. However, it has to be
+            # created so it makes it easier to handle the adding of the
+            # combobox later on.
             # Create a horizontal layout for the combo box and label
             options_hbox = qt.QHBoxLayout()
-
             # Label for the combo box
             options_label = qt.QLabel('Options : ')
             options_label.setStyleSheet("font-weight: bold")
             options_hbox.addWidget(options_label)
-
             # Create a combo box
             self.options_combobox = qt.QComboBox()
             self.options_combobox.setEditable(True)
             options_hbox.addWidget(self.options_combobox)
+            # Do not add the Combobox to the layout (keep commented) unless
+            # you want to see it in the pop-up.
+            # layout.addLayout(options_hbox)
 
-            # Add the combo box layout to the main layout
-            layout.addLayout(options_hbox)
+            # Create a horizontal layout for the explanations label
+            info_hbox = qt.QHBoxLayout()
+
+            message = ('\nAdjust the DropDown count.\n'
+                       'Then, edit the option names.\n'
+                       'If no text, option number will\n'
+                       'be used as default.\n'
+                       'N.B. Options will be saved sorted.\n')
+
+            # Label for the combo box
+            options_label_info = qt.QLabel(message)
+            info_hbox.addWidget(options_label_info)
+            layout.addLayout(info_hbox)
 
             # Create a horizontal layout for number of options input
             num_options_hbox = qt.QHBoxLayout()
-
             # Label for number of options
             num_options_label = qt.QLabel('Number of options: ')
             num_options_label.setStyleSheet("font-weight: bold")
             num_options_hbox.addWidget(num_options_label)
-
             # Spin box to specify the number of options
             self.num_options_spinbox = qt.QSpinBox()
             self.num_options_spinbox.setMinimum(1)  # At least 1 option
-            self.num_options_spinbox.setMaximum(100)  # Arbitrary upper limit
+            self.num_options_spinbox.setMaximum(50)  # Arbitrary upper limit
             self.num_options_spinbox.setValue(5)  # Default value
             num_options_hbox.addWidget(self.num_options_spinbox)
-
             # Add the spin box layout to the main layout
             layout.addLayout(num_options_hbox)
 
@@ -1789,7 +1801,9 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
 
             def clearLayout(layout):
                 """
-                Recursively clears all widgets and sublayouts from the given layout.
+                Recursively clears all widgets and sublayouts from the given
+                layout.
+                :param layout: pop-up widget layout.
                 """
                 while layout.count():
                     child = layout.takeAt(0)
@@ -1800,9 +1814,12 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                             child.layout())  # Recursively clear sublayouts
 
             def updateOptionFields():
+                """
+                Dynamically adjust the number of options text field based on
+                the number of options selected.
+                """
                 # Clear the text fields from the options layout
                 clearLayout(self.options_edit_layout)
-
                 # Clear all items from the combo box
                 self.options_combobox.clear()
 
@@ -1810,11 +1827,9 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                 for i in range(self.num_options_spinbox.value):
                     # Add text fields
                     option_hbox = qt.QHBoxLayout()
-                    option_label = qt.QLabel(f"Optionkl {i + 1}:")
+                    option_label = qt.QLabel(f"Option {i + 1}:")
                     option_line_edit = qt.QLineEdit()
-                    # option_line_edit.setText(f"Option {i + 1}")  # Default text
-                    option_line_edit.setText(f"ww {i+1}")  # Default text
-
+                    option_line_edit.setText(f"")  # Default text
 
                     option_hbox.addWidget(option_label)
                     option_hbox.addWidget(option_line_edit)
@@ -1823,55 +1838,19 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                     # Add item to the combo box
                     self.options_combobox.addItem(option_line_edit.text)
 
-                    # Connect the line edit to update the combo box item dynamically
-                    # def updateComboBoxItem(line_edit, index=i):
-                    #     if index < self.options_combobox.count():
-                    #         self.options_combobox.setItemText(index,
-                    #                                           line_edit.text)
-                    #     else:
-                    #         self.options_combobox.addItem(line_edit.text)
-                    #
-                    # option_line_edit.textChanged.connect(
-                    #     lambda _, le=option_line_edit: updateComboBoxItem(le))
-
-                    # Connect the line edit to update the combo box item dynamically
-                    # def updateComboBoxItem(line_edit, index=i):
-                    #     if index < self.options_combobox.count():
-                    #         self.options_combobox.setItemText(index,
-                    #                                           line_edit.text)
-                    #     else:
-                    #         self.options_combobox.addItem(line_edit.text)
-                    #
-                    # option_line_edit.textChanged.connect(
-                    #     lambda _, le=option_line_edit: updateComboBoxItem(le))
-                    # def updateComboBoxItem(option_line_edit, index=i):
-                    #     print('index', index)
-                    #     print('option combobox, self.', self.options_combobox)
-                    #     print('option line edit', option_line_edit)
-                    #     if index < self.options_combobox.count():
-                    #         self.options_combobox.setItemText(index,
-                    #                                           option_line_edit.text)
-                    #     else:
-                    #         self.options_combobox.addItem(option_line_edit.text)
-                    #
-                    # option_line_edit.textChanged.connect(
-                    #     lambda _, le=option_line_edit: updateComboBoxItem(le))
                     # Define a function to update the combo box dynamically
                     def updateComboBoxItem(option_line_edit, index=i):
-                        print('index:', index)
-                        print('option combobox, self.:', self.options_combobox)
-                        print('option line edit:', option_line_edit)
                         if index < self.options_combobox.count:
-                            self.options_combobox.setItemText(index,
-                                                              option_line_edit.text)
+                            self.options_combobox.setItemText(
+                                index,option_line_edit.text)
                         else:
                             self.options_combobox.addItem(option_line_edit.text)
 
-                    # Use lambda with default argument to capture the current value of `i`
+                    # Use lambda with default argument to capture the current
+                    # value of `i`
                     option_line_edit.textChanged.connect(
                         lambda _, le=option_line_edit,
                                idx=i: updateComboBoxItem(le, idx))
-
 
                 # Populate the combo box with default values
                 self.options_combobox.clear()
@@ -1927,13 +1906,25 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                 item_found = False
                 for i, (combobox_name, _) in enumerate(
                         self.config_yaml['comboboxes'].items()):
+                    print('item found true')
+                    print('combobox name', combobox_name)
+                    print('obejct-name', object_name)
                     if combobox_name == object_name:
                         item_found = True
 
                 if item_found == False:
                     # append
+                    print('item false')
+                    print('object name', object_name)
+                    print('option dict', options_dict)
+
+
                     self.config_yaml['comboboxes'].update(
                         {object_name: options_dict})
+
+                print('before save', self.config_yaml['comboboxes'])
+
+
         elif self.item_added == 'freetextbox':
             label_found = False
             for i, (_, label) in enumerate(

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -1553,6 +1553,7 @@ class ConfigureClassificationWindow(qt.QWidget):
             self.segmenter, self.config_yaml, 'freetextbox', self.edit_conf)
         configureSingleClassificationItemWindow.show()
 
+    @enter_function
     def push_add_combobox(self):
         self.close()
 
@@ -1686,6 +1687,7 @@ class ConfigureClassificationWindow(qt.QWidget):
 
 
 class ConfigureSingleClassificationItemWindow(qt.QWidget):
+    @enter_function
     def __init__(self, segmenter, classification_config_yaml, item_added,
                  edit_conf, parent=None):
         super(ConfigureSingleClassificationItemWindow, self).__init__(parent)
@@ -1708,19 +1710,27 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
 
         layout.addLayout(name_hbox)
 
-        if self.item_added == 'combobox':
-            options_hbox = qt.QHBoxLayout()
+        # if self.item_added == 'combobox':
+        #
+        #     print('entering item added combobox init')
+        #
+        #     options_hbox = qt.QHBoxLayout()
+        #     options_label = qt.QLabel('Options : ')
+        #     options_label.setStyleSheet("font-weight: bold")
+        #     options_hbox.addWidget(options_label)
+        #
+        #     self.options_combobox = qt.QComboBox()
+        #     self.options_combobox.setEditable(True)
+        #
+        #     options_hbox.addWidget(self.options_combobox)
+        #
+        #     layout.addLayout(options_hbox)
 
-            options_label = qt.QLabel('Options : ')
-            options_label.setStyleSheet("font-weight: bold")
-            options_hbox.addWidget(options_label)
+        self.edit_combobox(layout)
 
-            self.options_combobox = qt.QComboBox()
-            self.options_combobox.setEditable(True)
 
-            options_hbox.addWidget(self.options_combobox)
 
-            layout.addLayout(options_hbox)
+
 
         self.save_button = qt.QPushButton('Save')
         self.save_button.clicked.connect(self.push_save)
@@ -1734,9 +1744,150 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
         self.setWindowTitle("Configure Classification Item")
         self.resize(200, 100)
 
+    @enter_function
+    def edit_combobox(self, layout):
+        if self.item_added == 'combobox':
+            print('Entering item added combobox init')
+
+            # Create a horizontal layout for the combo box and label
+            options_hbox = qt.QHBoxLayout()
+
+            # Label for the combo box
+            options_label = qt.QLabel('Options : ')
+            options_label.setStyleSheet("font-weight: bold")
+            options_hbox.addWidget(options_label)
+
+            # Create a combo box
+            self.options_combobox = qt.QComboBox()
+            self.options_combobox.setEditable(True)
+            options_hbox.addWidget(self.options_combobox)
+
+            # Add the combo box layout to the main layout
+            layout.addLayout(options_hbox)
+
+            # Create a horizontal layout for number of options input
+            num_options_hbox = qt.QHBoxLayout()
+
+            # Label for number of options
+            num_options_label = qt.QLabel('Number of options: ')
+            num_options_label.setStyleSheet("font-weight: bold")
+            num_options_hbox.addWidget(num_options_label)
+
+            # Spin box to specify the number of options
+            self.num_options_spinbox = qt.QSpinBox()
+            self.num_options_spinbox.setMinimum(1)  # At least 1 option
+            self.num_options_spinbox.setMaximum(100)  # Arbitrary upper limit
+            self.num_options_spinbox.setValue(5)  # Default value
+            num_options_hbox.addWidget(self.num_options_spinbox)
+
+            # Add the spin box layout to the main layout
+            layout.addLayout(num_options_hbox)
+
+            # Container for text fields to edit options
+            self.options_edit_layout = qt.QVBoxLayout()
+            layout.addLayout(self.options_edit_layout)
+
+            def clearLayout(layout):
+                """
+                Recursively clears all widgets and sublayouts from the given layout.
+                """
+                while layout.count():
+                    child = layout.takeAt(0)
+                    if child.widget():
+                        child.widget().deleteLater()  # Delete the widget
+                    elif child.layout():
+                        clearLayout(
+                            child.layout())  # Recursively clear sublayouts
+
+            def updateOptionFields():
+                # Clear the text fields from the options layout
+                clearLayout(self.options_edit_layout)
+
+                # Clear all items from the combo box
+                self.options_combobox.clear()
+
+                # Create new text fields and populate the combo box
+                for i in range(self.num_options_spinbox.value):
+                    # Add text fields
+                    option_hbox = qt.QHBoxLayout()
+                    option_label = qt.QLabel(f"Optionkl {i + 1}:")
+                    option_line_edit = qt.QLineEdit()
+                    # option_line_edit.setText(f"Option {i + 1}")  # Default text
+                    option_line_edit.setText(f"ww {i+1}")  # Default text
+
+
+                    option_hbox.addWidget(option_label)
+                    option_hbox.addWidget(option_line_edit)
+                    self.options_edit_layout.addLayout(option_hbox)
+
+                    # Add item to the combo box
+                    self.options_combobox.addItem(option_line_edit.text)
+
+                    # Connect the line edit to update the combo box item dynamically
+                    # def updateComboBoxItem(line_edit, index=i):
+                    #     if index < self.options_combobox.count():
+                    #         self.options_combobox.setItemText(index,
+                    #                                           line_edit.text)
+                    #     else:
+                    #         self.options_combobox.addItem(line_edit.text)
+                    #
+                    # option_line_edit.textChanged.connect(
+                    #     lambda _, le=option_line_edit: updateComboBoxItem(le))
+
+                    # Connect the line edit to update the combo box item dynamically
+                    # def updateComboBoxItem(line_edit, index=i):
+                    #     if index < self.options_combobox.count():
+                    #         self.options_combobox.setItemText(index,
+                    #                                           line_edit.text)
+                    #     else:
+                    #         self.options_combobox.addItem(line_edit.text)
+                    #
+                    # option_line_edit.textChanged.connect(
+                    #     lambda _, le=option_line_edit: updateComboBoxItem(le))
+                    # def updateComboBoxItem(option_line_edit, index=i):
+                    #     print('index', index)
+                    #     print('option combobox, self.', self.options_combobox)
+                    #     print('option line edit', option_line_edit)
+                    #     if index < self.options_combobox.count():
+                    #         self.options_combobox.setItemText(index,
+                    #                                           option_line_edit.text)
+                    #     else:
+                    #         self.options_combobox.addItem(option_line_edit.text)
+                    #
+                    # option_line_edit.textChanged.connect(
+                    #     lambda _, le=option_line_edit: updateComboBoxItem(le))
+                    # Define a function to update the combo box dynamically
+                    def updateComboBoxItem(option_line_edit, index=i):
+                        print('index:', index)
+                        print('option combobox, self.:', self.options_combobox)
+                        print('option line edit:', option_line_edit)
+                        if index < self.options_combobox.count:
+                            self.options_combobox.setItemText(index,
+                                                              option_line_edit.text)
+                        else:
+                            self.options_combobox.addItem(option_line_edit.text)
+
+                    # Use lambda with default argument to capture the current value of `i`
+                    option_line_edit.textChanged.connect(
+                        lambda _, le=option_line_edit,
+                               idx=i: updateComboBoxItem(le, idx))
+
+
+                # Populate the combo box with default values
+                self.options_combobox.clear()
+                for i in range(self.num_options_spinbox.value):
+                    self.options_combobox.addItem(f"Option {i + 1}")
+
+            # Connect spin box to update the option fields dynamically
+            self.num_options_spinbox.valueChanged.connect(updateOptionFields)
+
+    @enter_function
     def push_save(self):
         current_label_name = self.name_line_edit.text
         object_name = current_label_name.replace(' ', '_')
+
+        print('current label name', current_label_name)
+        print('object name push save', object_name)
 
         if self.item_added == 'checkbox':
             label_found = False
@@ -1750,7 +1901,9 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                 self.config_yaml['checkboxes'].update(
                     {object_name: current_label_name.capitalize()})
         elif self.item_added == 'combobox':
+            print('in item added == comboxe')
             if self.options_combobox.count == 0:
+                print('in if combo box ==0')
                 msg = qt.QMessageBox()
                 msg.setWindowTitle('ERROR : No Drop Down Options Defined')
                 msg.setText(
@@ -1761,9 +1914,13 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
                     self.push_error_no_dropdown_option_defined)
                 msg.exec()
             else:
+                print('combo box should have been added')
                 options_dict = {}
                 combobox_option_items = [self.options_combobox.itemText(i) for i
                                          in range(self.options_combobox.count)]
+
+                print('combo box options items ', combobox_option_items)
+
                 for option in combobox_option_items:
                     options_dict.update({option.replace(' ', '_'): option})
 


### PR DESCRIPTION
This PR:
- Enables to modify DropDown labels from the Configuration UI windows (options will be sorted by default)

How to test?
1. Open Slicer, whether a new configuration or continue from existing output folder
2. Click on Configure Classification.,
3. Edit DropDown Options
4. Save
5. Perform classification tasks ...

Expected result: new or removed dropdown menu should appear in the classification labels UI in SlicerCART.

