### PR TITLE
Fixes issue 128 Label selection in segmentation UI does not work if project continued from existing output folder or no new configuration selected

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -536,8 +536,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       self.update_ui()
 
-
-
   def validateBIDS(self, path):
         validator = BIDSValidator()
         is_structure_valid = True
@@ -2008,7 +2006,6 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
   @enter_function
   def onDropDownButton_label_select(self, value):
-      print('label', value)
       self.current_label_index = value
       label = self.config_yaml["labels"][value]
       self.setUpperAndLowerBoundHU(label["lower_bound_HU"], label["upper_bound_HU"])

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -269,10 +269,14 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             slicer.app.layoutManager().setLayout(
                 slicer.vtkMRMLLayoutNode.SlicerLayoutOneUpGreenSliceView)
             
-        self.ui.dropDownButton_label_select.clear()
-        for label in self.config_yaml["labels"]:
-            self.ui.dropDownButton_label_select.addItem(label["name"])
-  
+
+  @enter_function
+  def set_segmentation_config_ui(self):
+      self.ui.dropDownButton_label_select.clear()
+
+      for label in self.config_yaml["labels"]:
+          self.ui.dropDownButton_label_select.addItem(label["name"])
+
   @enter_function
   def set_classification_config_ui(self):
 
@@ -526,7 +530,13 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           remaining_list_first = self.select_next_working_case()
 
       self.set_patient(remaining_list_first)
+
+      # Assign segmentation labels in the segmentation UI
+      self.set_segmentation_config_ui()
+
       self.update_ui()
+
+
 
   def validateBIDS(self, path):
         validator = BIDSValidator()
@@ -1996,7 +2006,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         removedNode = self.lineDetails.pop(lastMarkupNode.GetName())
         
+  @enter_function
   def onDropDownButton_label_select(self, value):
+      print('label', value)
       self.current_label_index = value
       label = self.config_yaml["labels"][value]
       self.setUpperAndLowerBoundHU(label["lower_bound_HU"], label["upper_bound_HU"])


### PR DESCRIPTION
This PR fixes issue 128 Label selection in segmentation UI does not work if project continued from existing output folder or no new configuration selected

Now, whether the user use a new configuration, start directly segmentation from scratch or continue from existing output folder, once an output folder has been selected, the user becomes able to select labels directly from SlicerCART UI.

<img width="482" alt="image" src="https://github.com/user-attachments/assets/af23a769-4cec-41e8-8fb1-496ee8296e75" />
