### PR TITLE
Fixes issue 139 Add toggle segmentation masks to enable visuzalization of segmentation masks when iterating through cases

### DIFF
--- a/SlicerCART/src/Resources/UI/SlicerCART.ui
+++ b/SlicerCART/src/Resources/UI/SlicerCART.ui
@@ -50,7 +50,7 @@
              <item row="3" column="1">
               <widget class="QPushButton" name="pushButton_ToggleVisibility">
                <property name="text">
-                <string>Visibility: ON</string>
+                <string>Load masks</string>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -154,11 +154,22 @@
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="LoadSegmentation">
-             <property name="text">
-              <string>Load segmentation...</string>
-             </property>
-            </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <item>
+                 <widget class="QPushButton" name="LoadSegmentation">
+                   <property name="text">
+                     <string>Load segmentation</string>
+                   </property>
+                 </widget>
+               </item>
+               <item>
+                 <widget class="QPushButton" name="ToggleSegmentation">
+                   <property name="text">
+                     <string>Load masks</string>
+                   </property>
+                 </widget>
+               </item>
+             </layout>
            </item>
            <item>
             <widget class="QPushButton" name="CompareSegmentVersions">

--- a/SlicerCART/src/Resources/UI/SlicerCART.ui
+++ b/SlicerCART/src/Resources/UI/SlicerCART.ui
@@ -165,7 +165,7 @@
                <item>
                  <widget class="QPushButton" name="ToggleSegmentation">
                    <property name="text">
-                     <string>Load masks2</string>
+                     <string>Load latest masks</string>
                    </property>
                   <property name="checkable">
                    <bool>true</bool>

--- a/SlicerCART/src/Resources/UI/SlicerCART.ui
+++ b/SlicerCART/src/Resources/UI/SlicerCART.ui
@@ -50,7 +50,7 @@
              <item row="3" column="1">
               <widget class="QPushButton" name="pushButton_ToggleVisibility">
                <property name="text">
-                <string>Load masks</string>
+                <string>Segments visibles</string>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -165,8 +165,11 @@
                <item>
                  <widget class="QPushButton" name="ToggleSegmentation">
                    <property name="text">
-                     <string>Load masks</string>
+                     <string>Load masks2</string>
                    </property>
+                  <property name="checkable">
+                   <bool>true</bool>
+                  </property>
                  </widget>
                </item>
              </layout>

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -126,6 +126,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # Track if segmentation is modified
     self.segmentation_modified = False
     self.observer_tags = {}
+    self.count = 0
 
     # MB: code below added in the configuration setup since its absence
     # created issues when trying to load cases after selecting a volume folder.
@@ -205,115 +206,46 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     
     self.MostRecentPausedCasePath = ""
 
-    # print('before adding observer')
-    # # Observe the scene for added nodes
-    # self.sceneObserverTag = slicer.mrmlScene.AddObserver(
-    #     slicer.vtkMRMLScene.NodeAddedEvent, self.onNodeAdded
-    # )
-    # print('after adding observer')
-    # # # Check if a segmentation node is already in the scene
-    # segmentationNode = self.findSegmentationNode()
-    # if segmentationNode:
-    #     print("Found existing segmentation node, adding paint observer.")
-    #     self.addPaintObserver(segmentationNode)
 
-
-  @enter_function
-  def onNodeAdded(self, caller, event):
-      """
-      Callback function triggered when a node is added to the scene.
-      """
-      # The added node is passed as the third argument
-      addedNode = event  # This is the added node
-
-      # if isinstance(caller, slicer.vtkMRMLSegmentationNode):
-      if isinstance(addedNode, slicer.vtkMRMLSegmentationNode):
-          print("Segmentation node added, adding paint observer.")
-          self.addPaintObserver(addedNode)
-
-      else:
-          print(
-              f"Node added is not a segmentation node: {caller.GetClassName()}")
-
-  @enter_function
-  def addPaintObserver(self, segmentationNode):
-      """
-      Add an observer to monitor painting or erasing in a segmentation node.
-      """
-      if segmentationNode:
-          print("Adding paint observer to segmentation node.")
-          segmentationNode.AddObserver(
-              vtk.vtkCommand.ModifiedEvent, self.onSegmentationModified
-          )
-
-  @enter_function
-  def onSegmentationModified(self, caller, event):
-      """
-      Callback triggered when the segmentation node is modified.
-      """
-      print("Segmentation node modified.")
-      self.updateButtonColor()
-
-  @enter_function
-  def updateButtonColor(self):
-      """
-      Updates the button color when segmentation changes occur.
-      """
-      self.ui.pushButton_ToggleVisibility.setStyleSheet(
-          f"background-color: green;")
-
-  @enter_function
-  def segmentationChangedCallback(self, caller, event):
-      print("Segmentation was changed!")
-      # You can add specific logic here to identify painting or erasing events
-
-
-  # Define the callback function
   @enter_function
   def visibilityModifiedCallback(self, caller, event):
+
       print("The paint effect was modified!", event)
-      # self.ui.pushButton_ToggleVisibility.setChecked(True)
-      # self.ui.pushButton_ToggleVisibility.setStyleSheet(
-      #     f"background-color: {self.color_active};")
-      # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
+
+      self.count += 1
+      print('self count', self.count)
+
+      jacques = False
+
+      # if self.ui.pushButton_ToggleVisibility.isChecked():
+      #     self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(true)
+      #     return
       #
-      # # Logic to handle the modification
-      # # Example: Check what segment is modified or what area is affected
-      # print("Paint effect callback triggered.")
-      # self.resetObserver(self.segmentationNode)
-      # If segments have been drawn and are now visible, update button to active (green)
+      # else
 
-      if self.ui.pushButton_ToggleVisibility.isChecked():
-        print('in true segments visibiles')
-        return
-        # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
-        # self.ui.pushButton_ToggleVisibility.setStyleSheet(f"background-color : "
-        #                                                   f"{self.color_active}")
+      # self.onPushButton_ToggleVisibility()
+      # Retrieve segment IDs
+      segmentIDs = vtk.vtkStringArray()
+      self.segmentationNode.GetSegmentation().GetSegmentIDs(segmentIDs)
 
-      else:
-          print('in false segment visible')
+      # Check visibility for each segment
+      for i in range(segmentIDs.GetNumberOfValues()):
+          segmentID = segmentIDs.GetValue(i)
+          isVisible = caller.GetSegmentVisibility(segmentID)
+          print(f"Segment '{segmentID}' visibility: {isVisible}")
 
-          if self.mask_visible_flag_level2:
-              return
-          else:
-              self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(
-                  True)
+          if isVisible:
               self.ui.pushButton_ToggleVisibility.setStyleSheet(
                   f"background-color : "
                   f"{self.color_active}")
-              self.mask_visible_flag_level2 = True
+              # self.ui.pushButton_ToggleVisibility.setChecked(True)
+              jacques = True
+              # return
 
+      self.ui.pushButton_ToggleVisibility.setChecked(jacques)
 
-
-
-          # self.mask_visible_flag_level2 = False
-          # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
-          # self.ui.pushButton_ToggleVisibility.setStyleSheet(
-          #     f"background-color : {self.color_inactive}")
-
-
-
-
+      print('jacques: ', jacques)
+      print('toggle sel is checkd: ', self.ui.pushButton_ToggleVisibility.isChecked())
 
 
 
@@ -322,41 +254,73 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
 
 
-      if self.mask_visible_flag_level2:
-          print('in if self mask visible level2')
-          self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
-          self.ui.pushButton_ToggleVisibility.setStyleSheet(f"background-color : "
-                                                              f"{self.color_active}")
-      else:
-          print('else visibilitymodifed callback mask visible flag false')
-          self.ui.pushButton_ToggleVisibility.setChecked(False)
-          self.ui.pushButton_ToggleVisibility.setStyleSheet(
-              f"background-color: {self.color_inactive};")
-          self.mask_visible_flag_level2 = True
-
-          # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
 
 
 
       # if self.ui.pushButton_ToggleVisibility.isChecked():
-      #   print('in true segments visibiles')
-      #   self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
-      #   self.ui.pushButton_ToggleVisibility.setStyleSheet(f"background-color : "
-      #                                                     f"{self.color_active}")
-
-
-
-
-      # else:
-      #   print('in false segment visible')
+      #     print('Toggle Visibility button is checked: ',
+      #           self.ui.pushButton_ToggleVisibility.isChecked())
+      #     self.ui.pushButton_ToggleVisibility.setStyleSheet(
+      #         f"background-color : "
+      #         f"{self.color_active}")
+      #     print('color should be green')
+      #     return
       #
-      #   if
+      # else:
+      #     print('Toggle Visibility button is not checked (else): ')
+      #
+      #     print('self mask visible flag level2: ',
+      #           self.mask_visible_flag_level2)
+      #     if self.mask_visible_flag_level2:
+      #         print('flag level2 true')
+      #         self.ui.pushButton_ToggleVisibility.setStyleSheet(
+      #             f"background-color : "
+      #             f"{self.color_active}")
+      #         self.ui.pushButton_ToggleVisibility.setChecked(True)
+      #         self.mask_visible_flag_level2 = False
+      #
+      #     else:
+      #         print('mask visibile flag level2 false')
+      #         self.ui.pushButton_ToggleVisibility.setStyleSheet(
+      #             f"background-color : {self.color_inactive}")
+      #         self.ui.pushButton_ToggleVisibility.setChecked(False)
+      #         self.mask_visible_flag_level2 = True
 
+  # # ALSMOST WORKING Define the callback function
+  # @enter_function
+  # def visibilityModifiedCallback(self, caller, event):
+  #     print("The paint effect was modified!", event)
+  #
+  #     self.count += 1
+  #     print('self count', self.count)
+  #
+  #     if self.ui.pushButton_ToggleVisibility.isChecked():
+  #       print('Toggle Visibility button is checked: ', self.ui.pushButton_ToggleVisibility.isChecked())
+  #       self.ui.pushButton_ToggleVisibility.setStyleSheet(
+  #           f"background-color : "
+  #           f"{self.color_active}")
+  #       print('color should be green')
+  #       return
+  #
+  #     else:
+  #         print('Toggle Visibility button is not checked (else): ')
+  #
+  #         print('self mask visible flag level2: ', self.mask_visible_flag_level2)
+  #         if self.mask_visible_flag_level2:
+  #             print('flag level2 true')
+  #             self.ui.pushButton_ToggleVisibility.setStyleSheet(
+  #                 f"background-color : "
+  #                 f"{self.color_active}")
+  #             self.ui.pushButton_ToggleVisibility.setChecked(True)
+  #             self.mask_visible_flag_level2 = False
+  #
+  #         else:
+  #             print('mask visibile flag level2 false')
+  #             self.ui.pushButton_ToggleVisibility.setStyleSheet(
+  #                 f"background-color : {self.color_inactive}")
+  #             self.ui.pushButton_ToggleVisibility.setChecked(False)
+  #             self.mask_visible_flag_level2 = True
 
-        # self.ui.pushButton_ToggleVisibility.setChecked(True)
-        # self.ui.pushButton_ToggleVisibility.setStyleSheet(
-        #     f"background-color: {self.color_active};")
-        # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
 
 
   def setup_configuration(self):
@@ -1093,6 +1057,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       else:
             self.segmentationNode=slicer.util.getNodesByClass('vtkMRMLSegmentationNode')[0]
             self.segmentationNode.GetSegmentation().AddEmptySegment(self.segment_name)
+
+      # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
+
 
       return self.segment_name
 
@@ -2641,70 +2608,50 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
   #         self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
   #
   #         # self.get_latest_path()
+  # ALMOST WORKING
+  # @enter_function
+  # def onPushButton_ToggleVisibility(self):
+  #
+  #     print('ToggleVisibility', self.ui.pushButton_ToggleVisibility.isChecked())
+  #
+  #     self.mask_visible_flag_level2 = self.ui.pushButton_ToggleVisibility.isChecked()
+  #
+  #     if self.ui.pushButton_ToggleVisibility.isChecked():
+  #       print('in true segments visibiles')
+  #       self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
+  #       self.ui.pushButton_ToggleVisibility.setStyleSheet(f"background-color : "
+  #                                                         f"{self.color_active}")
+  #
+  #     else:
+  #       print('in false segment22 visible')
+  #       # self.mask_visible_flag_level2 = False
+  #       self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
+  #       self.ui.pushButton_ToggleVisibility.setStyleSheet(
+  #           f"background-color : {self.color_inactive}")
+  #       self.mask_visible_flag_level2 = False
+
 
   @enter_function
   def onPushButton_ToggleVisibility(self):
 
       print('ToggleVisibility', self.ui.pushButton_ToggleVisibility.isChecked())
 
-      # self.segmentationNode.AddObserver(
-      #     self.segmentationNode.GetSegmentation().SegmentModified,
-      #     self.paintModifiedCallback)
-
-
       if self.ui.pushButton_ToggleVisibility.isChecked():
-        print('in true segments visibiles')
-        self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
-        self.ui.pushButton_ToggleVisibility.setStyleSheet(f"background-color : "
-                                                          f"{self.color_active}")
-
-
-
+          print('in true segments visibiles')
+          self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
+          self.ui.pushButton_ToggleVisibility.setStyleSheet(
+              f"background-color : "
+              f"{self.color_active}")
 
       else:
-        print('in false segment visible')
-        # self.mask_visible_flag_level2 = False
-        self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
-        self.ui.pushButton_ToggleVisibility.setStyleSheet(
-            f"background-color : {self.color_inactive}")
-        self.mask_visible_flag_level2 = False
+          print('in false segment22 visible')
+          # self.mask_visible_flag_level2 = False
+          self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
+          self.ui.pushButton_ToggleVisibility.setStyleSheet(
+              f"background-color : {self.color_inactive}")
+          self.mask_visible_flag_level2 = False
 
 
-
-  # self.startTimerForActions()
-      # self.previousAction = 'segmentation'
-      # print('value of visibl', self.ui.pushButton_ToggleVisibility.isChecked())
-      # if self.ui.pushButton_ToggleVisibility.isChecked():
-      #     print('in if toggle visb checked')
-      #     self.ui.pushButton_ToggleVisibility.setStyleSheet(
-      #         f"background-color : {self.color_active}")
-      #     # self.ui.pushButton_ToggleVisibility.setText('Visibility: ON')
-      #     self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
-      #
-      #     latest_version_path = self.get_latest_path()
-      #
-      #     print('latest_version_path', latest_version_path)
-      #
-      #     if latest_version_path is None:
-      #         print('no segmentatino found nothing to do')
-      #         return
-      #
-      #     print('segmentation found')
-      #     self.replace_segments(latest_version_path)
-      #     # self.loadSegmentation(latest_version_path)
-      #     print('segmentation laoded')
-      #
-      # else:
-      #     print('in else toggle visib checked')
-      #     # self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : yellowgreen")
-      #     # self.ui.pushButton_ToggleVisibility.setText('Visibility: ON')
-      #     # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
-      #     self.ui.pushButton_ToggleVisibility.setStyleSheet(
-      #         f"background-color : {self.color_inactive}")
-      #     # self.ui.pushButton_ToggleVisibility.setText('Visibility: OFF')
-      #     self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
-      #
-      #     # self.get_latest_path()
 
   def togglePaintMask(self):
         if self.ui.pushButton_TogglePaintMask.isChecked():

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -117,6 +117,10 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.saved_selected = False # Flag to load correctly the first case
     self.currentOutputPath = None
     self.currentVolumeFilename = None
+    self.mask_loaded = False
+    # Define colors to be used in the application
+    self.color_active = "yellowgreen"
+    self.color_inactive = "indianred"
 
     # MB: code below added in the configuration setup since its absence
     # created issues when trying to load cases after selecting a volume folder.
@@ -130,6 +134,10 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.ui.SaveSegmentationButton.connect('clicked(bool)', self.onSaveSegmentationButton)
     self.ui.SelectOutputFolder.connect('clicked(bool)', self.onSelectOutputFolder)
     self.ui.LoadSegmentation.connect('clicked(bool)', self.onLoadSegmentation)
+    # self.ui.ToggleSegmentation.connect('clicked(bool)',
+    #                          self.toggle_segmentation_masks)
+    # self.ui.ToggleSegmentation.setStyleSheet("background-color: red")
+
     self.ui.CompareSegmentVersions.connect('clicked(bool)', self.onCompareSegmentVersions)
     self.ui.LoadClassification.connect('clicked(bool)', self.onLoadClassification)
     self.ui.SaveClassificationButton.connect('clicked(bool)', self.onSaveClassificationButton)
@@ -177,7 +185,10 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.ui.LB_HU.setMaximum(29000)
 
     self.ui.pushButton_ToggleFill.setStyleSheet("background-color : indianred")
-    self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : yellowgreen")
+    # self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : yellowgreen")
+    self.ui.pushButton_ToggleVisibility.setStyleSheet(f"background-color : "
+                                                      f"{self.color_inactive}")
+
     self.ui.lcdNumber.setStyleSheet("background-color : black")
     
     self.MostRecentPausedCasePath = ""
@@ -270,12 +281,84 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 slicer.vtkMRMLLayoutNode.SlicerLayoutOneUpGreenSliceView)
             
 
+  # @enter_function
+  # def set_segmentation_config_ui(self):
+  #     self.ui.dropDownButton_label_select.clear()
+  #
+  #     if self.ui.pushButton_ToggleFill.isChecked():
+  #         print('in if')
+  #
+  #         segmentation_name = ("Segmentation_1")
+  #         segmentation_node = slicer.mrmlScene.GetNodesByName(segmentation_name)
+  #
+  #         # segmentation_node = Dev.get_segmentation_node(self)
+  #         segment_ids = segmentation_node.GetSegmentation().GetSegmentIDs()
+  #         # segment_ids = Dev.get_active_segments(self, segmentation_node).GetSegmentIds()
+  #
+  #         print('segment ids', segment_ids)
+  #
+  #
+  #         for segment_id in segment_ids:
+  #             segment_name = self.segmentationNode.GetSegmentation().GetSegment(
+  #                 segment_id).GetName()
+  #
+  #             print('segment name', segment_name)
+  #
+  #             self.ui.dropDownButton_label_select.addItem(segment_name)
+  #
+  #         self.segmentEditorWidget = slicer.modules.segmenteditor.widgetRepresentation().self().editor
+  #         self.segmentEditorNode = self.segmentEditorWidget.mrmlSegmentEditorNode()
+  #
+  #         # Set the active segmentation node
+  #         self.segmentEditorWidget.setSegmentationNode(segmentation_node)
+  #
+  #     else:
+  #         print('in else set segmentation config id')
+  #         for label in self.config_yaml["labels"]:
+  #             self.ui.dropDownButton_label_select.addItem(label["name"])
+
   @enter_function
   def set_segmentation_config_ui(self):
       self.ui.dropDownButton_label_select.clear()
 
-      for label in self.config_yaml["labels"]:
-          self.ui.dropDownButton_label_select.addItem(label["name"])
+      print('value of self.pushBu', self.ui.pushButton_ToggleFill.isChecked())
+
+      if self.ui.pushButton_ToggleVisibility.isChecked():
+          print('in if')
+
+          segmentation_name = "Segmentation_1"
+          segmentation_node = slicer.mrmlScene.GetNodesByName(segmentation_name)
+          segmentation_node = segmentation_node.GetItemAsObject(0)
+
+          print('segmentation node', segmentation_node)
+
+
+          # segmentation_node = Dev.get_segmentation_node(self)
+          segment_ids = segmentation_node.GetSegmentation().GetSegmentIDs()
+          # segment_ids = Dev.get_active_segments(self, segmentation_node).GetSegmentIds()
+
+          print('segment ids', segment_ids)
+
+
+          for segment_id in segment_ids:
+              segment_name = self.segmentationNode.GetSegmentation().GetSegment(
+                  segment_id).GetName()
+
+              print('segment name', segment_name)
+
+              self.ui.dropDownButton_label_select.addItem(segment_name)
+
+          self.segmentEditorWidget = slicer.modules.segmenteditor.widgetRepresentation().self().editor
+          self.segmentEditorNode = self.segmentEditorWidget.mrmlSegmentEditorNode()
+
+          # Set the active segmentation node
+          self.segmentEditorWidget.setSegmentationNode(segmentation_node)
+
+      else:
+          print('in else set segmentation config id')
+          for label in self.config_yaml["labels"]:
+              self.ui.dropDownButton_label_select.addItem(label["name"])
+
 
   @enter_function
   def set_classification_config_ui(self):
@@ -1789,7 +1872,95 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.openLoadSegmentationWindow()
       else:
           return
-      
+
+  # @enter_function
+  # def set_button_color(self, button, color):
+  #     button.setStyleSheet(f"background-color: {color}")
+
+  # @enter_function
+  # def toggle_segmentation_masks(self):
+  #     print('blalblal toggle segmentaitno mask')
+  #     self.mask_loaded = not self.mask_loaded
+  #     print("self.mask_loaded: ", self.mask_loaded)
+  #     # if self.mask_loaded:
+  #     #     self.set_button_color(self.ui.ToggleSegmentation, self.color_active)
+  #     # else:
+  #     #     self.set_button_color(self.ui.ToggleSegmentation, self.color_inactive)
+  #
+
+  @enter_function
+  def get_latest_path(self):
+      latest_version = self.get_latest_existing_version()
+
+      print('latest version', latest_version)
+      print('type latest version', type(latest_version))
+
+      # latest_version_str = self.parse_version_int_to_str(latest_version)
+      # print('latest version str', latest_version_str)
+
+      latest_path = os.path.join(
+          self.currentOutputPath, "{}_{}"f"{ConfigPath.INPUT_FILE_EXTENSION[1:]}".format(
+              self.currentVolumeFilename, latest_version))
+
+      print('latest path to test', latest_path)
+      if os.path.exists(latest_path):
+          print('os path exists')
+          return latest_path
+
+      else:
+          # latest_path = self.currentCasePath
+          print('lastes path in else')
+
+      # print('latest path', latest_path)
+      #
+      # return latest_path
+
+
+  @enter_function
+  def get_latest_existing_version(self):
+      version = self.getCurrentSegmentationVersion()
+      print('version ', version)
+      version_int = self.parse_version_to_int(version)
+      version_int -= 1
+      print('version int', version_int)
+      if version_int == 0:
+          version = version
+      else:
+         version = self.parse_version_int_to_str(version_int)
+      print('version', version)
+      return version
+
+  @enter_function
+  def parse_version_to_int(self, version_string):
+      print('version string', version_string)
+      version_formatted = version_string[1:]
+      print('version formatted', version_formatted)
+      print('type version form', type(version_formatted))
+      version = int(version_formatted)
+      return version
+
+  @enter_function
+  def parse_version_int_to_str(self, version_int):
+      return f"v{version_int:02d}"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   def openLoadSegmentationWindow(self):
       segmentationInformationPath = f'{self.currentOutputPath}{os.sep}{self.currentVolumeFilename}_SegmentationInformation.csv'
       segmentationInformation_df = None
@@ -1942,6 +2113,83 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 if str(segment_id) == str(label['value']) or str(segment_id) == str(label['name']):
                     self.segmentationNode.GetSegmentation().SetSegmentIndex(str(segment_id), label['value']-1)
 
+        # Set curent segmenrts in dropdown menu
+
+  def replace_segments(self, latest_version_path):
+      segmentation_node = Dev.get_segmentation_node(self)
+      # segmentation = segmentation_node.GetSegmentation()
+      # segmentation.RemoveAllSegments()
+      # print('segments removed')
+
+      # Load the segmentation into a temporary node
+      temporary_segmentation_node = slicer.mrmlScene.AddNewNodeByClass(
+          "vtkMRMLSegmentationNode", "TemporarySegmentation"
+      )
+      if latest_version_path.endswith(".nrrd"):
+          slicer.util.loadSegmentation(latest_version_path,
+                                       temporary_segmentation_node)
+      elif latest_version_path.endswith(".nii") or latest_version_path.endswith(
+              ".nii.gz"):
+          labelmap_volume_node = slicer.util.loadLabelVolume(
+              latest_version_path)
+          slicer.modules.segmentations.logic().ImportLabelmapToSegmentationNode(
+              labelmap_volume_node, temporary_segmentation_node
+          )
+          slicer.mrmlScene.RemoveNode(
+              labelmap_volume_node)  # Remove labelmap after import
+
+      # Get the segmentation object from the nodes
+      temp_segmentation = temporary_segmentation_node.GetSegmentation()
+      target_segmentation = segmentation_node.GetSegmentation()
+
+      # Clear existing segments in the target node
+      segment_ids = [target_segmentation.GetNthSegmentID(i) for i in
+                     range(target_segmentation.GetNumberOfSegments())]
+      for segment_id in segment_ids:
+          target_segmentation.RemoveSegment(segment_id)
+
+      print('target segmentat', target_segmentation)
+      print('type target', type(target_segmentation))
+      print('temp seg', temp_segmentation)
+      print('type temp', type(temp_segmentation))
+
+      # Copy segments from the temporary node to the target node
+      for i in range(temp_segmentation.GetNumberOfSegments()):
+          segment = temp_segmentation.GetNthSegment(i)
+          target_segmentation.AddSegment(segment)
+          for label in self.config_yaml["labels"]:
+              # Ensure that you compare the label value to the segment's name correctly
+              if str(label["value"]) == str(segment.GetName()):
+                  # Get the segment ID using the segment's name
+                  # segment = target_segmentation.GetSegment(f'{i}')
+                  print('segment id', segment)
+                  # target_segmentation.GetSegment(segment_id).SetName(
+                  #     label["name"])
+                  segment.SetName(label["name"])
+
+                  rgb_r = label["color_r"]/255
+                  rgb_g = label["color_g"]/255
+                  rgb_b = label["color_b"]/255
+
+                  segment.SetColor(rgb_r, rgb_g, rgb_b)
+
+      # Remove the temporary node
+      slicer.mrmlScene.RemoveNode(temporary_segmentation_node)
+
+      # RENDU ICI --- DOIT FAIRE EN SORTE QUE SI JE MODIFIE ET SAVE UNE
+      # VERSION PRECEDENTE, LA VERSION SAUVEGEARDEE EST ELLE MODIFIE
+      # COMPARER AVEC LE LOADSEGMENTATION ET SV ESEMGENTATION AU BESOIN
+      # VALIDER QUE LA GEOMETRIE EST OK!
+
+
+
+
+
+
+      # self.loadSegmentation(latest_version_path)
+      # self.set_segmentation_config_ui()
+
+
   def getAllSegmentNames(self):
         list_of_segment_ids = self.segmentationNode.GetSegmentation().GetSegmentIDs()
         list_of_segment_names = []
@@ -2058,17 +2306,57 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           self.ui.pushButton_ToggleFill.setText('Fill: OFF')
           self.segmentationNode.GetDisplayNode().SetOpacity2DFill(100)
 
+  # def onPushButton_ToggleVisibility(self):
+  #     self.startTimerForActions()
+  #     self.previousAction = 'segmentation'
+  #     if self.ui.pushButton_ToggleVisibility.isChecked():
+  #         self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : indianred")
+  #         self.ui.pushButton_ToggleVisibility.setText('Visibility: OFF')
+  #         self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
+  #     else:
+  #         self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : yellowgreen")
+  #         self.ui.pushButton_ToggleVisibility.setText('Visibility: ON')
+  #         self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
+
+  @enter_function
   def onPushButton_ToggleVisibility(self):
       self.startTimerForActions()
       self.previousAction = 'segmentation'
+      print('value of visibl', self.ui.pushButton_ToggleVisibility.isChecked())
       if self.ui.pushButton_ToggleVisibility.isChecked():
-          self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : indianred")
-          self.ui.pushButton_ToggleVisibility.setText('Visibility: OFF')
-          self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
-      else:
-          self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : yellowgreen")
-          self.ui.pushButton_ToggleVisibility.setText('Visibility: ON')
+          print('in if toggle visb checked')
+          self.ui.pushButton_ToggleVisibility.setStyleSheet(
+              f"background-color : {self.color_active}")
+          # self.ui.pushButton_ToggleVisibility.setText('Visibility: ON')
           self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
+
+          latest_version_path = self.get_latest_path()
+
+          print('latest_version_path', latest_version_path)
+
+          if latest_version_path is None:
+              print('no segmentatino found nothing to do')
+              return
+
+          print('segmentation found')
+          self.replace_segments(latest_version_path)
+          # self.loadSegmentation(latest_version_path)
+          print('segmentation laoded')
+
+
+
+
+      else:
+          print('in else toggle visib checked')
+          # self.ui.pushButton_ToggleVisibility.setStyleSheet("background-color : yellowgreen")
+          # self.ui.pushButton_ToggleVisibility.setText('Visibility: ON')
+          # self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(True)
+          self.ui.pushButton_ToggleVisibility.setStyleSheet(
+              f"background-color : {self.color_inactive}")
+          # self.ui.pushButton_ToggleVisibility.setText('Visibility: OFF')
+          self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(False)
+
+          self.get_latest_path()
 
   def togglePaintMask(self):
         if self.ui.pushButton_TogglePaintMask.isChecked():

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -212,10 +212,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       print("The paint effect was modified!", event)
 
-      self.count += 1
       print('self count', self.count)
 
-      jacques = False
+      toggle_to_set = False
 
       # if self.ui.pushButton_ToggleVisibility.isChecked():
       #     self.segmentationNode.GetDisplayNode().SetAllSegmentsVisibility(true)
@@ -239,12 +238,11 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                   f"background-color : "
                   f"{self.color_active}")
               # self.ui.pushButton_ToggleVisibility.setChecked(True)
-              jacques = True
-              # return
+              toggle_to_set = True
 
-      self.ui.pushButton_ToggleVisibility.setChecked(jacques)
+      self.ui.pushButton_ToggleVisibility.setChecked(toggle_to_set)
 
-      print('jacques: ', jacques)
+      print('jacques: ', toggle_to_set)
       print('toggle sel is checkd: ', self.ui.pushButton_ToggleVisibility.isChecked())
 
 

--- a/SlicerCART/src/scripts/LoadSegmentationWindow.py
+++ b/SlicerCART/src/scripts/LoadSegmentationWindow.py
@@ -83,16 +83,10 @@ class LoadSegmentationsWindow(qt.QWidget):
            segmentation_file_extension = ".seg.nrrd"
 
        absolute_path_to_segmentation = f'{self.segmenter.currentOutputPath}{os.sep}{self.segmenter.currentVolumeFilename}_{selected_version}{segmentation_file_extension}'
-
-       print('absolute_path_to_segmentation', absolute_path_to_segmentation)
-
        self.segmenter.loadSegmentation(absolute_path_to_segmentation)
 
        self.close()
 
    @enter_function
    def pushCancel(self):
-
-       print('self cancel')
-
        self.close()

--- a/SlicerCART/src/scripts/LoadSegmentationWindow.py
+++ b/SlicerCART/src/scripts/LoadSegmentationWindow.py
@@ -72,6 +72,7 @@ class LoadSegmentationsWindow(qt.QWidget):
       self.setWindowTitle("Load Segmentations")
       self.resize(800, 400)
 
+   @enter_function
    def pushLoad(self):
        selected_version = self.versionDropdown.currentText
 
@@ -82,9 +83,16 @@ class LoadSegmentationsWindow(qt.QWidget):
            segmentation_file_extension = ".seg.nrrd"
 
        absolute_path_to_segmentation = f'{self.segmenter.currentOutputPath}{os.sep}{self.segmenter.currentVolumeFilename}_{selected_version}{segmentation_file_extension}'
+
+       print('absolute_path_to_segmentation', absolute_path_to_segmentation)
+
        self.segmenter.loadSegmentation(absolute_path_to_segmentation)
 
        self.close()
 
+   @enter_function
    def pushCancel(self):
+
+       print('self cancel')
+
        self.close()

--- a/SlicerCART/src/utils/development_helpers.py
+++ b/SlicerCART/src/utils/development_helpers.py
@@ -61,14 +61,6 @@ class Dev:
     def get_number_of_segments(self, segments):
         return segments.GetNumberOfSegments()
 
-    def get_segment_names_list(self, segments):
-        segment_names = []
-        for i in range(Dev.get_number_of_segments(self, segments)):
-            segment = segments.GetNthSegment(i)
-            segment_name = segment.GetName()
-            segment_names.append(segment.GetName())
-        return segment_names
-
 
     # Check functions
     @enter_function

--- a/SlicerCART/src/utils/development_helpers.py
+++ b/SlicerCART/src/utils/development_helpers.py
@@ -61,6 +61,14 @@ class Dev:
     def get_number_of_segments(self, segments):
         return segments.GetNumberOfSegments()
 
+    def get_segment_names_list(self, segments):
+        segment_names = []
+        for i in range(Dev.get_number_of_segments(self, segments)):
+            segment = segments.GetNthSegment(i)
+            segment_name = segment.GetName()
+            segment_names.append(segment.GetName())
+        return segment_names
+
 
     # Check functions
     @enter_function


### PR DESCRIPTION
This PR:

- Add the button Load latest masks aside load segmentation --- enables to load the latest segmentation version available if so. If no version, will load nothing. If the latest version is modified, and saved, then a new version equalling latest_version +1 is created. If load latest masks checked, then latest version will automatically be loaded when iterating through different cases.

- Rename the button Toggle Visibility to Segments visibles --- fixes many bugs to make available the toggling of viewing the segments in the slicer viewer.

How to test?
1. Open Slicer, start from a new configuration or from existing output folder
2. Create segmentation
3. Load latest version, edit it and save it.
4. Go back to the case that you just saved and load latest mask
5. Toggle segments visible if you want so
6. Edit (optional)
7. Save again

Expected results: ability to toggle back and forward  visibility of segments and load latest version