### PR TITLE
Fixes issue 147 Config values do not adjust properly (but worked before)

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -124,7 +124,9 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # MB: code below added in the configuration setup since its absence
     # created issues when trying to load cases after selecting a volume folder.
     self.config_yaml = ConfigPath.open_project_config_file()
-    self.current_label_index = self.config_yaml['labels'][0]['value']
+    self.current_label_index = (self.config_yaml['labels'][0]['value']-1)
+    print('set up current label index initial', self.current_label_index)
+
   
     self.ui.PauseTimerButton.setText('Pause')
     self.ui.SelectVolumeFolder.connect('clicked(bool)', self.onSelectVolumesFolderButton)
@@ -839,12 +841,16 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                               self.visibilityModifiedCallback)
 
       # restart the current timer 
-      self.timers[self.current_label_index] = Timer(number=self.current_label_index)
+      self.timers[self.current_label_index] = Timer(
+          number=self.current_label_index)
       # reset tool 
       self.segmentEditorWidget.setActiveEffectByName("No editing")
       
   # Load all segments at once    
+  @enter_function
   def createNewSegments(self):
+      print('self config labels new segments', self.config_yaml["labels"])
+      # self.config_yaml = ConfigPath.open_project_config_file()
       for label in self.config_yaml["labels"]:
           self.onNewLabelSegm(label["name"], label["color_r"], label["color_g"], label["color_b"], label["lower_bound_HU"], label["upper_bound_HU"])
           first_label_name = self.config_yaml["labels"][0]["name"]
@@ -878,10 +884,13 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       Segmentation = self.segmentationNode.GetSegmentation()
       self.SegmentID = Segmentation.GetSegmentIdBySegmentName(segment_name)
       segment = Segmentation.GetSegment(self.SegmentID)
-      segment.SetColor(label_color_r/255,label_color_g/255,label_color_b/255) 
+      segment.SetColor(label_color_r/255,label_color_g/255,label_color_b/255)
+      print('segment name', segment_name)
+
       self.onPushButton_select_label(segment_name, label_LB_HU, label_UB_HU)
    
-  def onPushButton_select_label(self, segment_name, label_LB_HU, label_UB_HU):  
+  @enter_function
+  def onPushButton_select_label(self, segment_name, label_LB_HU, label_UB_HU):
       self.segmentationNode=slicer.util.getNodesByClass('vtkMRMLSegmentationNode')[0]
       Segmentation = self.segmentationNode.GetSegmentation()
       self.SegmentID = Segmentation.GetSegmentIdBySegmentName(segment_name)
@@ -889,9 +898,21 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       self.updateCurrentPath()
       self.LB_HU = label_LB_HU
       self.UB_HU = label_UB_HU
+
+      print('in on push button select label')
+      print('self current label index', self.current_label_index)
+      print('self timers', self.timers)
+      print('self timers type', type(self.timers))
+      print('times number', Timer(number=self.current_label_index))
+      print('self most recent paused path', self.MostRecentPausedCasePath)
+      # print('self currentcase path', self.CurrentCasePath)
+      print('self mostrecent paused path', self.MostRecentPausedCasePath)
+
+
   
       if (self.MostRecentPausedCasePath != self.currentCasePath and self.MostRecentPausedCasePath != ""):
-        self.timers[self.current_label_index] = Timer(number=self.current_label_index) # new path, new timer
+        self.timers[self.current_label_index] = Timer(
+            number=self.current_label_index) # new path, new timer
       
       self.timer_router()
 
@@ -1014,13 +1035,27 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           self.enableSegmentAndPaintButtons()
 
   # for the timer Class not the LCD one
+  @enter_function
   def timer_router(self):
+      print('self.current_label_index', self.current_label_index)
+      print('self timers', self.timers)
+      self.config_yaml = ConfigPath.open_project_config_file()
+      # self.config_yaml = ConfigPath.set_config_values(self.config_yaml)
+
+      print('self.current_label_index2', self.current_label_index)
+      print('self timers2', self.timers)
+      print('types self timers', type(self.timers))
+      for i in range(0, len(self.timers)):
+          print(' obejctif', i, self.timers[i].__dict__)
+
+      # self.timers[self.current_label_index].start()
       self.timers[self.current_label_index].start()
+
       self.flag = True
       
       timer_index = 0
       for timer in self.timers:
-          if timer_index != self.current_label_index:
+          if timer_index != (self.current_label_index):
               timer.stop()
           timer_index = timer_index + 1
             
@@ -1357,10 +1392,10 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
       currentSegmentationVersion = self.getCurrentSegmentationVersion()
 
-      # quality control check 
-      is_valid = self.qualityControlOfLabels()
-      if is_valid == False:
-          return
+      # # quality control check
+      # is_valid = self.qualityControlOfLabels()
+      # if is_valid == False:
+      #     return
 
       # Save if annotator_name is not empty and timer started:
       if self.annotator_name and self.time is not None:
@@ -1628,17 +1663,44 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           f'{self.currentOutputPath}{os.sep}'
           f'{self.currentVolumeFilename}{ConfigPath.INPUT_FILE_EXTENSION}')
 
+
+      print('currentoutput path', self.currentOutputPath)
+      print('current volume filename,', self.currentVolumeFilename)
+
+      print('configpath input fle ext', ConfigPath.INPUT_FILE_EXTENSION)
+      print('list of segmentation filenames', list_of_segmentation_filenames)
+
+
       version = 'v'
       if list_of_segmentation_filenames == []:
           version = version + "01"
       else:
-          existing_versions = [(int)(filename.split('_v')[1].split(".")[0]) for
-                               filename in list_of_segmentation_filenames]
+          # existing_versions = [(int)(filename.split('_v')[1].split(".")[0]) for
+          #                      filename in list_of_segmentation_filenames]
+          existing_versions = self.look_for_existing_version(
+              list_of_segmentation_filenames)
+
           next_version_number = max(existing_versions) + 1
           next_version_number = min(next_version_number, 99)  # max 99 versions
           version = f'{version}{next_version_number:02d}'
       return version
-      
+
+  @enter_function
+  def look_for_existing_version(self, list_of_segmentation_filenames):
+      existing_versions = []
+      for filename in list_of_segmentation_filenames:
+          # Check if '_v' exists in the filename
+          if '_v' in filename:
+              try:
+                  # Extract the version number after '_v'
+                  version = int(filename.split('_v')[1].split(".")[0])
+                  existing_versions.append(version)
+              except (IndexError, ValueError):
+                  # Handle cases where splitting or conversion to int fails
+                  print(f"Skipping invalid filename: {filename}")
+          else:
+              print(f"No version found in filename: {filename}")
+      return existing_versions
 
   def msg2_clicked(self, msg2_button):
       if msg2_button.text == 'OK':

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,34 +24,53 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 checkboxes:
-  Hemorrhage: Hemorrhage
-  dernier: Dernier
+  Anoxic_injury_checkbox: Anoxic injury
+  Brain_edema_checkbox: Brain edema
+  Craniectomy_checkbox: Craniectomy
+  Craniotomy_checkbox: Craniotomy
+  EDH_checkbox: EDH
+  EVD_checkbox: EVD
+  ICH_checkbox: ICH
+  IVH_checkbox: IVH
+  Infarct_checkbox: Infarct
+  Intra_axial_tumor_checkbox: Intra-axial tumor
+  Menigioma_checkbox: Meningioma
+  Metal_artifact_checkbox: Metal artifact
+  Midline_shift_checkbox: Midline shift
+  Motion_artifact_checkbox: Motion artifact
+  Multiple_lesions_checkbox: Multiple lesions
+  Normal_checkbox: Normal
+  Pressure_monitor_checkbox: Pressure monitor
+  SAH_checkbox: SAH
+  SDH_checkbox: SDH
+  Tonsillar_herniation_checkbox: Tonsillar herniation
 comboboxes:
-  Vertebral_Level:
-    C1-C2: C1-C2
-    C2-C3: C2-C3
-    C3-C4: C3-C4
-    C4-C5: C4-C5
-    C5-C6: C5-C6
-    C6-C7: C6-C7
-    C7-T1: C7-T1
-    Other: Other
-    T1-T2: T1-T2
-    T2-T3: T2-T3
-  abc:
+  atrophy:
+    atrophy_mild: Mild
+    atrophy_moderate: Moderate
+    atrophy_none: None
+    atrophy_severe: Severe
+  test_dd:
     '1': '1'
-    '2': '2'
-    a: a
-    b: b
+  ventricular_size:
+    ventricular_size_mild: Mild
+    ventricular_size_moderate: Moderate
+    ventricular_size_normal: Normal/proportional
+    ventricular_size_severe: Severe
+  white_matter_changes:
+    wmc_mild: Mild
+    wmc_moderate: Moderate
+    wmc_none: None
+    wmc_severe: Severe
 ct_window_level: 45
 ct_window_width: 85
 default_segmentation_directory: ''
 default_volume_directory: ''
 enable_debug: true
 freetextboxes:
-  '123': '123'
-  Comments-any: Comments-any
-  dragon: Dragon
+  cheese: Cheese
+  number_of_focal_points: Number of focal points
+  other_comments: Comments
 impose_bids_format: false
 input_filetype: '*.nii.gz'
 interpolate_value: 0
@@ -63,18 +82,18 @@ is_segmentation_requested: true
 is_semi_automatic_phe_tool_requested: true
 keep_working_list: true
 labels:
-- color_b: 122
-  color_g: 11
-  color_r: 123
+- color_b: 10
+  color_g: 10
+  color_r: 255
   lower_bound_HU: 30
-  name: anika
+  name: ICH
   upper_bound_HU: 90
   value: 1
-- color_b: 2
-  color_g: 222
-  color_r: 22
+- color_b: 70
+  color_g: 230
+  color_r: 230
   lower_bound_HU: 30
-  name: qwe
+  name: IVH
   upper_bound_HU: 90
   value: 2
 modality: MRI

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -20,54 +20,38 @@ KEYBOARD_SHORTCUTS:
 - button: pushButton_Interpolate
   callback: onPushButton_Interpolate
   shortcut: i
+- button: SaveClassificationButton
+  callback: onSaveClassificationButton
+  shortcut: c
 checkboxes:
-  Anoxic_injury_checkbox: Anoxic injury
-  Brain_edema_checkbox: Brain edema
-  Craniectomy_checkbox: Craniectomy
-  Craniotomy_checkbox: Craniotomy
-  EDH_checkbox: EDH
-  EVD_checkbox: EVD
-  ICH_checkbox: ICH
-  IVH_checkbox: IVH
-  Infarct_checkbox: Infarct
-  Intra_axial_tumor_checkbox: Intra-axial tumor
-  Menigioma_checkbox: Meningioma
-  Metal_artifact_checkbox: Metal artifact
-  Midline_shift_checkbox: Midline shift
-  Motion_artifact_checkbox: Motion artifact
-  Multiple_lesions_checkbox: Multiple lesions
-  Normal_checkbox: Normal
-  Pressure_monitor_checkbox: Pressure monitor
-  SAH_checkbox: SAH
-  SDH_checkbox: SDH
-  Tonsillar_herniation_checkbox: Tonsillar herniation
+  Hemorrhage: Hemorrhage
+  dernier: Dernier
 comboboxes:
-  atrophy:
-    atrophy_mild: Mild
-    atrophy_moderate: Moderate
-    atrophy_none: None
-    atrophy_severe: Severe
-  test_dd:
+  Vertebral_Level:
+    C1-C2: C1-C2
+    C2-C3: C2-C3
+    C3-C4: C3-C4
+    C4-C5: C4-C5
+    C5-C6: C5-C6
+    C6-C7: C6-C7
+    C7-T1: C7-T1
+    Other: Other
+    T1-T2: T1-T2
+    T2-T3: T2-T3
+  abc:
     '1': '1'
-  ventricular_size:
-    ventricular_size_mild: Mild
-    ventricular_size_moderate: Moderate
-    ventricular_size_normal: Normal/proportional
-    ventricular_size_severe: Severe
-  white_matter_changes:
-    wmc_mild: Mild
-    wmc_moderate: Moderate
-    wmc_none: None
-    wmc_severe: Severe
+    '2': '2'
+    a: a
+    b: b
 ct_window_level: 45
 ct_window_width: 85
 default_segmentation_directory: ''
 default_volume_directory: ''
 enable_debug: true
 freetextboxes:
-  cheese: Cheese
-  number_of_focal_points: Number of focal points
-  other_comments: Comments
+  '123': '123'
+  Comments-any: Comments-any
+  dragon: Dragon
 impose_bids_format: false
 input_filetype: '*.nii.gz'
 interpolate_value: 0
@@ -77,20 +61,20 @@ is_keyboard_shortcuts_requested: true
 is_mouse_shortcuts_requested: true
 is_segmentation_requested: true
 is_semi_automatic_phe_tool_requested: true
-keep_working_list: false
+keep_working_list: true
 labels:
-- color_b: 10
-  color_g: 10
-  color_r: 255
+- color_b: 122
+  color_g: 11
+  color_r: 123
   lower_bound_HU: 30
-  name: ICH
+  name: anika
   upper_bound_HU: 90
   value: 1
-- color_b: 70
-  color_g: 230
-  color_r: 230
+- color_b: 2
+  color_g: 222
+  color_r: 22
   lower_bound_HU: 30
-  name: IVH
+  name: qwe
   upper_bound_HU: 90
   value: 2
 modality: MRI


### PR DESCRIPTION
This PR:
- Fixes the index out of range errors from timers (self.timers) when there is only one label in the config file (or segmentation labels are modified and the results are to have only one label). 
- Explanation: in the init, self_current_label_index was starting at one since it is extracted from the config file labels value of the first element (which is always 1 in our case, but the timers like self.timers starts its index at 0). That may means that some previous time related segmentatino were incorrect per label although globally correct.

How to test?
1.Open Slicer, new configuration (or no) or continue from existing output folder
2. Ex edit labels to keep only one labels
3. Save segmentations
4. Start Slicer again and continue from existing output folder, and then modify segmentations and save them (will work)

N.B. On its way, segmentation versioning is now little bit more robust since if there are nifti files in the folder location where segmentation masks should be saved but not related to the versioning of segmentations, the saving (with appropriate version) will not fail.