### PR TITLE
Fixes Issue117 configuration UI setup update

### DIFF
--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -454,7 +454,8 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
             self.file_extension_combobox.setCurrentIndex(1)
 
         self.interpolate_combobox.setCurrentIndex(self.interpolate_selected)
-        self.keep_working_list_combobox.setCurrentIndex(self.keep_working_list_selected)
+        self.keep_working_list_combobox.setCurrentIndex(
+            self.keep_working_list_selected)
 
         self.segmentation_task_checkbox.setChecked(self.segmentation_selected)
         self.classification_task_checkbox.setChecked(
@@ -816,8 +817,6 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
 
         self.config_yaml['interpolate_value'] = self.interpolate_selected
         self.config_yaml['keep_working_list'] = self.keep_working_list_selected
-        print('before setting the keep workig-list',
-              self.keep_working_list_selected)
 
         if 'Red' in self.initial_view_selected:
             self.config_yaml['slice_view_color'] = 'Red'

--- a/SlicerCART/src/utils/ConfigPath.py
+++ b/SlicerCART/src/utils/ConfigPath.py
@@ -232,7 +232,6 @@ class ConfigPath():
 
         self.KEEP_WORKING_LIST = config["keep_working_list"]
         self.SAVE_UINT8 = config["save_uint8"]
-        self.ENABLE_DEBUG = config["enable_debug"]
 
         if self.MODALITY == 'CT':
             # then BIDS not mandatory because it is not yet supported
@@ -410,17 +409,6 @@ class ConfigPath():
             value: true (interpolation) or false (raw image, not interpolated)
         """
         self.INTERPOLATE_VALUE = value
-
-    # @enter_function
-    # def set_enable_debug(self, value):
-    #     """
-    #     set the activation of debug mode in Slicer Python console.
-    #
-    #     Args:
-    #         value: true or false
-    #     """
-    #     self.ENABLE_DEBUG = value
-
 
 
 # Creating an instance of ConfigPath. This ensures that all the same


### PR DESCRIPTION
This PR fixes https://github.com/neuropoly/slicercart/issues/117, related to adding the option in the configuration UI for keeping the working list if differences are found between working list and volume folders.

It also adds the configuratino UI to define keyboard short for saving classification (should have been in an other PR, but very somple to implement)

Modified the background cell color of configure segmentation and classification buttons in the UI