### PR TITLE
fixes issue #58 - Lasso Paint only selects regions within selected HU

### DIFF
--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -3439,7 +3439,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.previousAction = 'segmentation'
         self.ensure_active_segment_is_selected()
         self.segmentEditorWidget.setActiveEffectByName("Scissors")
-        self.segmentEditorNode.SetMasterVolumeIntensityMask(False)
+        self.segmentEditorNode.SetMasterVolumeIntensityMask(True)
         effect = self.segmentEditorWidget.activeEffect()
         effect.setParameter("Operation", "FillInside")
         effect.setParameter("Shape", "FreeForm")

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -94,7 +94,7 @@ labels:
   name: IVH
   upper_bound_HU: 90
   value: 2
-modality: CT
+modality: MRI
 remaining_list_filename: remaining_list.yaml
 require_empty: false
 save_uint8: true

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -94,7 +94,7 @@ labels:
   name: IVH
   upper_bound_HU: 90
   value: 2
-modality: MRI
+modality: CT
 remaining_list_filename: remaining_list.yaml
 require_empty: false
 save_uint8: true


### PR DESCRIPTION
**Previous behavior**
As described in #58, lasso paint fully colors region (fills it)

**Current behavior**
Colors only attributed to regions with specific HU 

![image](https://github.com/user-attachments/assets/56403176-a0a8-4d91-b522-31fd797f41a5)
![image](https://github.com/user-attachments/assets/4fcba566-06ad-4165-8341-a34185b5e1a7)
![image](https://github.com/user-attachments/assets/745e1c7c-1344-4439-ac59-036b6d90b9c6)
