### PR TITLE
Fixes #236 / #118 possibility to add filters on selected volumes folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ versions (e.g. segmentations generated automatically using models). This open-so
    * Maxime Bouthillier
    * Delphine Pilon
    * Neuropoly Team
+
+https://drive.google.com/drive/folders/1xVPfhznA60xt0YCgDhgdMWWbDP8-3LTK?usp=sharing

--- a/README.md
+++ b/README.md
@@ -30,4 +30,3 @@ versions (e.g. segmentations generated automatically using models). This open-so
    * Delphine Pilon
    * Neuropoly Team
 
-https://drive.google.com/drive/folders/1xVPfhznA60xt0YCgDhgdMWWbDP8-3LTK?usp=sharing

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ versions (e.g. segmentations generated automatically using models). This open-so
    * Delphine Pilon
    * Neuropoly Team
 
+
+CART DEMO: https://drive.google.com/file/d/1GJB0262RHs6XtidyyItAbBK-ZPaISCJ6/view?usp=sharing
+

--- a/SlicerCART/src/Resources/UI/SlicerCART.ui
+++ b/SlicerCART/src/Resources/UI/SlicerCART.ui
@@ -253,6 +253,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="SelectOutputFolder">
+          <property name="text">
+           <string>Select output folder</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -393,13 +400,6 @@
          <widget class="QLabel" name="CurrentStatus">
           <property name="text">
            <string>Segmentation Status : ...</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="SelectOutputFolder">
-          <property name="text">
-           <string>Select output folder</string>
           </property>
          </widget>
         </item>

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -766,6 +766,35 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # loading cases)
         self.CasesPaths = [item for item in self.CasesPaths if 'derivatives' not
                            in item]
+        
+        
+        if self.config_yaml["case_list_filters"]["inclusion"]:
+            filters_to_include = self.config_yaml["case_list_filters"]["inclusion"]
+        else:
+            # If no inclusion filters are set, we include all cases
+            filters_to_include = ['']
+            
+        if self.config_yaml["case_list_filters"]["exclusion"]:
+            filters_to_exclude = self.config_yaml["case_list_filters"]["exclusion"]
+        else:
+            # If no exclusion filters are set, we exclude nothing
+            filters_to_exclude = ['']
+        
+        temp_cases_paths = []
+        for case_path in self.CasesPaths:
+            for filter_i in filters_to_include:
+                for filter_e in filters_to_exclude:
+                    filter_e_lower = filter_e.lower()
+                    filter_i_lower = filter_i.lower()
+                    case_path_lower = case_path.lower()
+                    
+                    if filter_e_lower not in case_path_lower and \
+                       filter_i_lower in case_path_lower:
+                        temp_cases_paths.append(case_path)
+                
+        self.CasesPaths = temp_cases_paths
+        
+        Debug.print(self, self.CasesPaths)
 
         if not self.CasesPaths:
             message = ('No files found in the selected directory!'

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -771,32 +771,35 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self.config_yaml["case_list_filters"]["inclusion"]:
             filters_to_include = self.config_yaml["case_list_filters"]["inclusion"]
         else:
-            # If no inclusion filters are set, we include all cases
-            filters_to_include = ['']
+            filters_to_include = []
             
         if self.config_yaml["case_list_filters"]["exclusion"]:
             filters_to_exclude = self.config_yaml["case_list_filters"]["exclusion"]
         else:
-            # If no exclusion filters are set, we exclude nothing
-            filters_to_exclude = ['']
+            filters_to_exclude = []
         
-        temp_cases_paths = []
-        for case_path in self.CasesPaths:
-            for filter_i in filters_to_include:
-                for filter_e in filters_to_exclude:
-                    filter_e_lower = filter_e.lower()
-                    filter_i_lower = filter_i.lower()
-                    case_path_lower = case_path.lower()
-                    Debug.print(self, case_path_lower)
+        temp_cases = []
+        
+        e = 0
+        while e < len(filters_to_exclude):
+            thisFilter = filters_to_exclude[e].lower()
+            for index, case in enumerate(self.CasesPaths):
+                thisCase = case.lower()
+                if thisFilter not in thisCase:
+                    temp_cases.append(case)
+            e += 1
                     
-                    if filters_to_exclude != [""] and filter_e_lower not in case_path_lower and \
-                       filter_i_lower in case_path_lower:
-                        temp_cases_paths.append(case_path)
+        i = 0
+        while i < len(filters_to_include):
+            thisFilter = filters_to_include[i].lower()
+            for index, case in enumerate(self.CasesPaths):
+                thisCase = case.lower()
+                if thisFilter in thisCase and case not in temp_cases:
+                    temp_cases.append(case)
+            i += 1
+                    
+        self.CasesPaths = temp_cases
         
-        self.CasesPaths = temp_cases_paths
-        
-        Debug.print(self, self.CasesPaths)
-
         if not self.CasesPaths:
             message = ('No files found in the selected directory!'
                        f'\n\nCurrent file extension configuration: '

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -792,7 +792,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             for case in master_list:
                 if exclusion and any(ex in case for ex in exclusion):
                     continue
-                if inclusion and not all(inc in case for inc in inclusion):
+                if inclusion and not any(inc in case for inc in inclusion):
                     continue
                 filtered_cases.append(case)
 

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -2582,7 +2582,7 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         initial_config_content = ConfigPath.get_initial_config_after_modif()
         temp_dict = ConfigPath.extract_config_classification(
             initial_config_content)
-
+        #Debug.print(self, "inclusion" + str(temp_dict["case_list_filters"]["inclusion"]))
         self.manage_workflow()
 
         # Update classification labels (part 2 of 2)

--- a/SlicerCART/src/SlicerCART.py
+++ b/SlicerCART/src/SlicerCART.py
@@ -787,11 +787,12 @@ class SlicerCARTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     filter_e_lower = filter_e.lower()
                     filter_i_lower = filter_i.lower()
                     case_path_lower = case_path.lower()
+                    Debug.print(self, case_path_lower)
                     
-                    if filter_e_lower not in case_path_lower and \
+                    if filters_to_exclude != [""] and filter_e_lower not in case_path_lower and \
                        filter_i_lower in case_path_lower:
                         temp_cases_paths.append(case_path)
-                
+        
         self.CasesPaths = temp_cases_paths
         
         Debug.print(self, self.CasesPaths)

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,10 +24,11 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion: []
-  inclusion:
+  exclusion:
   - t1
   - t2
+  - seg
+  inclusion: []
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,8 +24,14 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion: []
-  inclusion: []
+  exclusion:
+  - test1
+  - test2
+  - test3
+  inclusion:
+  - nuh1
+  - nuh2
+  - nuh3
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,14 +24,13 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion:
-  - test1
-  - test2
-  - test3
+  exclusion: []
   inclusion:
-  - nuh1
-  - nuh2
-  - nuh3
+  - '3333'
+  - '333'
+  - '33'
+  - '3'
+  - ''
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -66,7 +66,6 @@ default_segmentation_directory: ''
 default_volume_directory: ''
 enable_debug: true
 freetextboxes:
-  cheese: Cheese
   number_of_focal_points: Number of focal points
   other_comments: Comments
 impose_bids_format: false

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,8 +24,10 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion: []
-  inclusion: []
+  exclusion:
+  - t2
+  inclusion:
+  - t1
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -23,6 +23,9 @@ KEYBOARD_SHORTCUTS:
 - button: SaveClassificationButton
   callback: onSaveClassificationButton
   shortcut: c
+case_list_filters:
+  exclusion: []
+  inclusion: []
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,11 +24,8 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion:
-  - t3
-  inclusion:
-  - t1
-  - t2
+  exclusion: []
+  inclusion: []
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -96,9 +96,9 @@ labels:
   name: IVH
   upper_bound_HU: 90
   value: 2
-modality: MRI
+modality: CT
 remaining_list_filename: remaining_list.yaml
 require_empty: false
 save_uint8: true
-slice_view_color: Yellow
+slice_view_color: Red
 working_list_filename: working_list.yaml

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,10 +24,9 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion:
-  - hei!
+  exclusion: []
   inclusion:
-  - hello
+  - t1
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,10 +24,8 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion:
-  - t2
-  inclusion:
-  - t1
+  exclusion: []
+  inclusion: []
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,13 +24,10 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion: []
+  exclusion:
+  - hei!
   inclusion:
-  - '3333'
-  - '333'
-  - '33'
-  - '3'
-  - ''
+  - hello
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -25,7 +25,9 @@ KEYBOARD_SHORTCUTS:
   shortcut: c
 case_list_filters:
   exclusion: []
-  inclusion: []
+  inclusion:
+  - t1
+  - t2
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy
@@ -96,7 +98,7 @@ labels:
   name: IVH
   upper_bound_HU: 90
   value: 2
-modality: CT
+modality: MRI
 remaining_list_filename: remaining_list.yaml
 require_empty: false
 save_uint8: true

--- a/SlicerCART/src/configuration_config.yml
+++ b/SlicerCART/src/configuration_config.yml
@@ -24,9 +24,11 @@ KEYBOARD_SHORTCUTS:
   callback: onSaveClassificationButton
   shortcut: c
 case_list_filters:
-  exclusion: []
+  exclusion:
+  - t3
   inclusion:
   - t1
+  - t2
 checkboxes:
   Anoxic_injury_checkbox: Anoxic injury
   Craniectomy_checkbox: Craniectomy

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -2503,11 +2503,11 @@ class ImposeCaseListFiltersWindow(qt.QWidget):
         
         inclusion_table_view_header_hbox.addWidget(inclusion_title_label)
         
-        add_inclusion_filter_button = qt.QPushButton('Add Inclusion Filter')
-        add_inclusion_filter_button.setFixedWidth(180)
-        add_inclusion_filter_button.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed)
+        self.add_inclusion_filter_button = qt.QPushButton('Add Inclusion Filter')
+        self.add_inclusion_filter_button.setFixedWidth(180)
+        self.add_inclusion_filter_button.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed)
         
-        inclusion_table_view_header_hbox.addWidget(add_inclusion_filter_button)
+        inclusion_table_view_header_hbox.addWidget(self.add_inclusion_filter_button)
         
         layout.addLayout(inclusion_table_view_header_hbox)
         layout.addSpacing(5) 
@@ -2535,11 +2535,11 @@ class ImposeCaseListFiltersWindow(qt.QWidget):
 
         exclusion_table_view_header_hbox.addWidget(exclusion_title_label)
         
-        add_exclusion_filter_button = qt.QPushButton('Add Exclusion Filter')
-        add_exclusion_filter_button.setFixedWidth(180)
-        add_exclusion_filter_button.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed)
+        self.add_exclusion_filter_button = qt.QPushButton('Add Exclusion Filter')
+        self.add_exclusion_filter_button.setFixedWidth(180)
+        self.add_exclusion_filter_button.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed)
         
-        exclusion_table_view_header_hbox.addWidget(add_exclusion_filter_button)
+        exclusion_table_view_header_hbox.addWidget(self.add_exclusion_filter_button)
         
         layout.addLayout(exclusion_table_view_header_hbox)
         layout.addWidget(self.exclusion_table_view)
@@ -2565,9 +2565,6 @@ class ImposeCaseListFiltersWindow(qt.QWidget):
         layout.addSpacing(15) 
         layout.addWidget(separator2)
         layout.addSpacing(15) 
-        
-        self.previous_button = qt.QPushButton('Previous')
-        layout.addWidget(self.previous_button)
 
         self.apply_button = qt.QPushButton('Apply')
         layout.addWidget(self.apply_button)
@@ -2578,4 +2575,80 @@ class ImposeCaseListFiltersWindow(qt.QWidget):
         self.setLayout(layout)
         self.setWindowTitle("Filter case list")
         self.resize(500, 600)
+
+    @enter_function
+    def connect_buttons_to_callbacks(self):
+        """
+        connect_buttons_to_callbacks
+
+        Args:
+        """
+        self.add_inclusion_filter_button.clicked.connect()
+        self.add_exclusion_filter_button.clicked.connect()
         
+        self.apply_button.clicked.connect(self.push_apply)
+        self.cancel_button.clicked.connect(self.push_cancel)
+    
+    @enter_function
+    def push_add_inclusion_filter(self):
+        """
+        push_add_inclusion_filter
+
+        Args:
+        """
+        addCaseListFiltersWindow = AddCaseListFiltersWindow(
+            self.segmenter, "include")
+        addCaseListFiltersWindow.show()
+        
+    @enter_function
+    def push_add_exclusion_filter(self):
+        """
+        push_add_exclusion_filter
+
+        Args:
+        """
+        addCaseListFiltersWindow = AddCaseListFiltersWindow(
+            self.segmenter, "exclude")
+        addCaseListFiltersWindow.show()
+
+    @enter_function
+    def push_apply(self):
+        """
+        push_apply
+
+        Args:
+        """
+        
+    @enter_function
+    def push_cancel(self):
+        """
+        push_cancel
+
+        Args:
+        """
+        slicerCARTConfigurationSetupWindow = SlicerCARTConfigurationSetupWindow(
+            self.segmenter)
+        slicerCARTConfigurationSetupWindow.show()
+        self.close()
+        
+class AddCaseListFiltersWindow(qt.QWidget):
+    @enter_function
+    def __init__(self, action, parent=None, ):
+        """
+        __init__
+
+        Args:
+            segmenter: Description of segmenter.
+            parent: Description of parent.
+        """
+        super(AddCaseListFiltersWindow, self).__init__(parent)
+
+        if action == "include":
+            pass
+        else:
+            pass
+            
+        layout = qt.QVBoxLayout()
+
+        self.setLayout(layout)
+        self.setWindowTitle("Add Case List Filters")

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -187,6 +187,15 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
         ct_window_width_hbox.addWidget(self.ct_window_width_line_edit)
 
         layout.addLayout(ct_window_width_hbox)
+        
+        separator = qt.QFrame()
+        separator.setFrameShape(qt.QFrame.HLine)
+        separator.setFrameShadow(qt.QFrame.Sunken)
+        separator.setLineWidth(5)
+        
+        layout.addSpacing(15) 
+        layout.addWidget(separator)
+        layout.addSpacing(15) 
 
         keyboard_shortcuts_hbox = qt.QHBoxLayout()
 
@@ -325,17 +334,44 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
         mouse_shortcuts_hbox.addWidget(self.mouse_shortcuts_checkbox)
 
         layout.addLayout(mouse_shortcuts_hbox)
+        
+        separator2 = qt.QFrame()
+        separator2.setFrameShape(qt.QFrame.HLine)
+        separator2.setFrameShadow(qt.QFrame.Sunken)
+        separator2.setLineWidth(5)
+        
+        layout.addSpacing(15) 
+        layout.addWidget(separator2)
+        layout.addSpacing(15) 
+
+                
+        config_buttons_hbox = qt.QHBoxLayout()
+        
         self.configure_segmentation_button = qt.QPushButton(
             'Configure Segmentation...')
         self.configure_segmentation_button.setStyleSheet(
             "background-color : #A6A6A6")
-        layout.addWidget(self.configure_segmentation_button)
-
+        self.configure_segmentation_button.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Fixed)
+        
+        config_buttons_hbox.addWidget(self.configure_segmentation_button)
+        
         self.configure_classification_button = qt.QPushButton(
             'Configure Classification...')
         self.configure_classification_button.setStyleSheet(
             "background-color : #A6A6A6")
-        layout.addWidget(self.configure_classification_button)
+        self.configure_classification_button.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Fixed)
+
+        config_buttons_hbox.addWidget(self.configure_classification_button)
+        
+        self.impose_case_list_filters_button = qt.QPushButton(
+            'Impose case list filters')
+        self.impose_case_list_filters_button.setStyleSheet(
+            "background-color : #A6A6A6")
+        self.impose_case_list_filters_button.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Fixed)
+
+        config_buttons_hbox.addWidget(self.impose_case_list_filters_button)
+        
+        layout.addLayout(config_buttons_hbox)
 
         self.previous_button = qt.QPushButton('Previous')
         layout.addWidget(self.previous_button)
@@ -406,6 +442,8 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
         self.cancel_button.clicked.connect(self.push_cancel)
         self.configure_segmentation_button.clicked.connect(
             self.push_configure_segmentation)
+        self.impose_case_list_filters_button.clicked.connect(
+             self.push_impose_case_list_filters)
 
         if self.modality_selected == 'CT':
             self.ct_modality_radio_button.setChecked(True)
@@ -744,6 +782,13 @@ class SlicerCARTConfigurationSetupWindow(qt.QWidget):
         configureClassificationWindow.show()
         self.close()
 
+    @enter_function
+    def push_impose_case_list_filters(self):
+        self.imposeCaseListFiltersWindow = ImposeCaseListFiltersWindow(
+            self.segmenter)
+        self.imposeCaseListFiltersWindow.show()
+        self.close()
+    
     @enter_function
     def push_previous(self):
         """
@@ -2431,3 +2476,106 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
             version_numbers = 0
 
         return version_numbers
+
+class ImposeCaseListFiltersWindow(qt.QWidget):
+    @enter_function
+    def __init__(self, segmenter, filter_config_yaml=None, parent=None):
+        
+        super(ImposeCaseListFiltersWindow, self).__init__(parent)
+        
+        self.segmenter = segmenter 
+        
+        #TODO: modify for starting with previous volumes
+        if filter_config_yaml is None:
+            self.config_yaml = ConfigPath.open_project_config_file()
+        else:
+            self.config_yaml = filter_config_yaml
+            
+        layout = qt.QVBoxLayout()
+
+        self.inclusion_table_view = qt.QTableWidget()
+        
+        inclusion_table_view_header_hbox = qt.QHBoxLayout()
+        
+        inclusion_title_label = qt.QLabel("Filters to include in the case list")
+        inclusion_title_label.setStyleSheet("font-weight: bold; font-size: 15px;")
+        inclusion_title_label.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Fixed)
+        
+        inclusion_table_view_header_hbox.addWidget(inclusion_title_label)
+        
+        add_inclusion_filter_button = qt.QPushButton('Add Inclusion Filter')
+        add_inclusion_filter_button.setFixedWidth(180)
+        add_inclusion_filter_button.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed)
+        
+        inclusion_table_view_header_hbox.addWidget(add_inclusion_filter_button)
+        
+        layout.addLayout(inclusion_table_view_header_hbox)
+        layout.addSpacing(5) 
+        layout.addWidget(self.inclusion_table_view)
+
+        self.inclusion_table_view.setRowCount(5)
+        self.inclusion_table_view.setColumnCount(2)
+        
+        separator1 = qt.QFrame()
+        separator1.setFrameShape(qt.QFrame.HLine)
+        separator1.setFrameShadow(qt.QFrame.Sunken)
+        separator1.setLineWidth(5)
+        
+        layout.addSpacing(15) 
+        layout.addWidget(separator1)
+        layout.addSpacing(15) 
+        
+        self.exclusion_table_view = qt.QTableWidget()
+        
+        exclusion_table_view_header_hbox = qt.QHBoxLayout()
+        
+        exclusion_title_label = qt.QLabel("Filters to exclude in the case list")
+        exclusion_title_label.setStyleSheet("font-weight: bold; font-size: 15px;")
+        exclusion_title_label.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Fixed)
+
+        exclusion_table_view_header_hbox.addWidget(exclusion_title_label)
+        
+        add_exclusion_filter_button = qt.QPushButton('Add Exclusion Filter')
+        add_exclusion_filter_button.setFixedWidth(180)
+        add_exclusion_filter_button.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed)
+        
+        exclusion_table_view_header_hbox.addWidget(add_exclusion_filter_button)
+        
+        layout.addLayout(exclusion_table_view_header_hbox)
+        layout.addWidget(self.exclusion_table_view)
+
+        self.exclusion_table_view.setRowCount(5)
+        self.exclusion_table_view.setColumnCount(2)
+    
+        self.inclusion_table_view.horizontalHeader().setStretchLastSection(
+        True)
+        self.inclusion_table_view.horizontalHeader().setSectionResizeMode(
+        qt.QHeaderView.Stretch)
+        
+        self.exclusion_table_view.horizontalHeader().setStretchLastSection(
+        True)
+        self.exclusion_table_view.horizontalHeader().setSectionResizeMode(
+        qt.QHeaderView.Stretch)
+        
+        separator2 = qt.QFrame()
+        separator2.setFrameShape(qt.QFrame.HLine)
+        separator2.setFrameShadow(qt.QFrame.Sunken)
+        separator2.setLineWidth(5)
+        
+        layout.addSpacing(15) 
+        layout.addWidget(separator2)
+        layout.addSpacing(15) 
+        
+        self.previous_button = qt.QPushButton('Previous')
+        layout.addWidget(self.previous_button)
+
+        self.apply_button = qt.QPushButton('Apply')
+        layout.addWidget(self.apply_button)
+
+        self.cancel_button = qt.QPushButton('Cancel')
+        layout.addWidget(self.cancel_button)
+
+        self.setLayout(layout)
+        self.setWindowTitle("Filter case list")
+        self.resize(500, 600)
+        

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -2484,6 +2484,10 @@ class ConfigureSingleClassificationItemWindow(qt.QWidget):
         return version_numbers
 
 class ImposeCaseListFiltersWindow(qt.QWidget):
+    
+    # Signal for when a cell is updated
+    cell_updated_signal = qt.Signal(str)
+    
     @enter_function
     def __init__(self, segmenter, filter_config_yaml=None, parent=None):
         
@@ -2611,8 +2615,18 @@ class ImposeCaseListFiltersWindow(qt.QWidget):
         self.setWindowTitle("Filter case list")
         self.resize(500, 600)
         
+        # self.cell_updated_signal.connect(self.)
+        
         self.connect_buttons_to_callbacks()
         
+    @enter_function
+    def register_inclusion_cell_data(self, row, column):
+        value = self.inclusion_table_view.item(row, column)
+        if value is not None:
+            new_filter = value.text()
+            self.case_list_filters["inclusion"].append(new_filter)
+
+    
     @enter_function
     def connect_buttons_to_callbacks(self):
         """

--- a/SlicerCART/src/scripts/InteractingClasses.py
+++ b/SlicerCART/src/scripts/InteractingClasses.py
@@ -1347,6 +1347,7 @@ class ConfigureSegmentationWindow(qt.QWidget):
             # msg.buttonClicked.connect(self.push_error_label_list_empty)
             msg.exec()
         else:
+            ConfigPath.write_config_file()
             self.close()
 
             configureSegmentationWindow = ConfigureSegmentationWindow(


### PR DESCRIPTION
**Previous behavior**
Upon selecting a volumes folder, it was impossible to filter/select specific cases (case paths) based off of characteristics in the file name.

**Current behavior**
A user can add filters of `inclusion` and `exclusion`. Loaded files from a selected volume are files **that all have** **_all inclusion filters within their file name and none of the exclusion filters within their file name_**. Casing does not matter (`t1 == T1`)

Some light UI changes included in this PR, could be applied to all windows:
  1. Adding fields to a window no longer requires a new window => Could reduce the amount of windows whenever something new is added (such as fields)
  2. Some spacing between configuration fields for readability

**Currently, limited testing has been done, this PR is for reviews and a showcase of the UI**
Action steps:

- [ ] Adequate testing of existing functionalities
- [ ] Testing on `Continue from existing segmentation` (filtering should not be an option)
- [ ] Adding a button to modify filters, thus changing the active case list during a single segmentation session, if session is a `New Configuration` type 